### PR TITLE
fix(lemonade): pin libwebsockets for so.20 compat

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -14,10 +14,16 @@
         overlays.default = final: prev: let
           xrt = final.callPackage ./pkgs/xrt {};
           fastflowlm = final.callPackage ./pkgs/fastflowlm {inherit xrt;};
+          # Lemonade RPM requires libwebsockets.so.20 (>= 4.4); pin to the
+          # version from nix-amd-ai's nixpkgs input for consumers on older channels.
+          libwebsockets-pinned = (import inputs.nixpkgs {inherit (final) system;}).libwebsockets;
         in {
           inherit xrt fastflowlm;
           xrt-plugin-amdxdna = final.callPackage ./pkgs/xrt-plugin-amdxdna {inherit xrt;};
-          lemonade = final.callPackage ./pkgs/lemonade {inherit fastflowlm;};
+          lemonade = final.callPackage ./pkgs/lemonade {
+            inherit fastflowlm;
+            libwebsockets = libwebsockets-pinned;
+          };
           llama-cpp-rocm = prev.llama-cpp-rocm;
           llama-cpp-vulkan = prev.llama-cpp.override {vulkanSupport = true;};
         };


### PR DESCRIPTION
## Summary
- The lemonade RPM links against `libwebsockets.so.20` (>= 4.4), but consumers on nixos-25.11 only have libwebsockets 4.3.5 (`so.19`), causing `autoPatchelfHook` to fail.
- Pin `libwebsockets` from nix-amd-ai's own nixpkgs input in the overlay so it works regardless of the consumer's nixpkgs channel.

## Test plan
- [x] `nix build .#lemonade` succeeds
- [ ] `nix flake check` passes
- [ ] Verified on nixos-25.11 consumer flake