### PR TITLE
fix(lemonade): preserve lemond args with spaces

### DIFF
--- a/modules/amd-npu.nix
+++ b/modules/amd-npu.nix
@@ -198,6 +198,34 @@ in {
       after = ["network-online.target"];
       wants = ["network-online.target"];
       wantedBy = ["multi-user.target"];
+      path = pathList ++ ["/run/current-system/sw"];
+      environment =
+        {
+          XILINX_XRT = "${xrt-combined}";
+          XRT_PATH = "${xrt-combined}";
+          LD_LIBRARY_PATH = "${xrt-combined}/lib${optionalROCmLibs}";
+          # Disable lemond's 300s upstream timeout so long prompt-processing
+          # phases (common with large agent system prompts on iGPU) don't
+          # abort before the first token. See lemonade-sdk/lemonade#1364.
+          LEMONADE_GLOBAL_TIMEOUT = "0";
+          LEMONADE_LLAMACPP_CPU_BIN = "${pkgs.llama-cpp}/bin/llama-server";
+          LEMONADE_WHISPERCPP_CPU_BIN = "${pkgs.whisper-cpp}/bin/whisper-server";
+          LEMONADE_LLAMACPP_ARGS = "--flash-attn ${cfg.lemonade.flashAttn}";
+        } // optionalAttrs cfg.enableImageGen {
+          LEMONADE_SDCPP_CPU_BIN = "${pkgs.stable-diffusion-cpp}/bin/sd-server";
+        } // optionalAttrs cfg.enableROCm {
+          LEMONADE_LLAMACPP_ROCM_BIN = "${pkgs.llama-cpp-rocm}/bin/llama-server";
+          LEMONADE_GGML_HIP_PATH = "${pkgs.llama-cpp-rocm}/lib/libggml-hip.so";
+        } // optionalAttrs (cfg.enableROCm && cfg.enableImageGen) {
+          LEMONADE_SDCPP_ROCM_BIN = "${pkgs.stable-diffusion-cpp-rocm}/bin/sd-server";
+        } // optionalAttrs cfg.enableVulkan {
+          LEMONADE_LLAMACPP_VULKAN_BIN = "${pkgs.llama-cpp-vulkan}/bin/llama-server";
+          LEMONADE_WHISPERCPP_VULKAN_BIN = "${pkgs.whisper-cpp-vulkan}/bin/whisper-server";
+        } // optionalAttrs cfg.enableFastFlowLM {
+          # Suppress FLM's auto-update probe in the lemond-spawned subprocess.
+          # New in FLM 0.9.41.
+          FLM_DISABLE_UPDATE_CHECK = "1";
+        };
       serviceConfig = {
         Type = "simple";
         User = cfg.lemonade.user;
@@ -206,33 +234,6 @@ in {
         RestartSec = "5s";
         KillSignal = "SIGINT";
         LimitMEMLOCK = "infinity";
-        Environment =
-          [
-            "XILINX_XRT=${xrt-combined}"
-            "XRT_PATH=${xrt-combined}"
-            "LD_LIBRARY_PATH=${xrt-combined}/lib${optionalROCmLibs}"
-            "PATH=${makeBinPath pathList}:/run/current-system/sw/bin"
-            # Disable lemond's 300s upstream timeout so long prompt-processing
-            # phases (common with large agent system prompts on iGPU) don't
-            # abort before the first token. See lemonade-sdk/lemonade#1364.
-            "LEMONADE_GLOBAL_TIMEOUT=0"
-            "LEMONADE_LLAMACPP_CPU_BIN=${pkgs.llama-cpp}/bin/llama-server"
-            "LEMONADE_WHISPERCPP_CPU_BIN=${pkgs.whisper-cpp}/bin/whisper-server"
-            "LEMONADE_LLAMACPP_ARGS=--flash-attn ${cfg.lemonade.flashAttn}"
-          ]
-          ++ optional cfg.enableImageGen "LEMONADE_SDCPP_CPU_BIN=${pkgs.stable-diffusion-cpp}/bin/sd-server"
-          ++ optionals cfg.enableROCm [
-            "LEMONADE_LLAMACPP_ROCM_BIN=${pkgs.llama-cpp-rocm}/bin/llama-server"
-            "LEMONADE_GGML_HIP_PATH=${pkgs.llama-cpp-rocm}/lib/libggml-hip.so"
-          ]
-          ++ optional (cfg.enableROCm && cfg.enableImageGen) "LEMONADE_SDCPP_ROCM_BIN=${pkgs.stable-diffusion-cpp-rocm}/bin/sd-server"
-          ++ optionals cfg.enableVulkan [
-            "LEMONADE_LLAMACPP_VULKAN_BIN=${pkgs.llama-cpp-vulkan}/bin/llama-server"
-            "LEMONADE_WHISPERCPP_VULKAN_BIN=${pkgs.whisper-cpp-vulkan}/bin/whisper-server"
-          ]
-          # Suppress FLM's auto-update probe in the lemond-spawned subprocess.
-          # New in FLM 0.9.41.
-          ++ optional cfg.enableFastFlowLM "FLM_DISABLE_UPDATE_CHECK=1";
       };
     };
   };


### PR DESCRIPTION
Thanks for putting this repo together!  I ran into a problem getting it setup and stumbled upon a bug with the most recent `--flash-attn` commit 885d7e8113ba820b0e37373a51ce89c50fdb9853.

## Issue

`llama-server` fails to start up and crashes due to `--flash-attn` flag missing an argument.

## Logs

Warning upon `nixos` deploy by `systemd`:

    May 22 08:26:53 wtr systemd[1]: /etc/systemd/system/lemond.service:18: Invalid environment assignment, ignoring: on

Later when attempting to load `llama-server` it fails because the `on` argument is missing.

    May 21 22:09:16 wtr lemond[974129]: 2026-05-21 22:09:16.750 [Info] (LlamaCpp) Starting llama-server...
    May 21 22:09:16 wtr lemond[974129]: 2026-05-21 22:09:16.751 [Info] (ProcessManager) Process started successfully, PID: 976242
    May 21 22:09:16 wtr lemond[974129]: Waiting for llama-server to be ready (timeout: 600s)...
    May 21 22:09:16 wtr lemond[974129]: 2026-05-21 22:09:16.804 [Error] (Process) error while handling argument "--flash-attn": expected value for argument
    May 21 22:09:16 wtr lemond[974129]: 2026-05-21 22:09:16.804 [Info] (Process) usage:
    May 21 22:09:16 wtr lemond[974129]: 2026-05-21 22:09:16.804 [Info] (Process) -fa,   --flash-attn [on|off|auto]       set Flash Attention use ('on', 'off', or 'auto', default: 'auto')
    May 21 22:09:16 wtr lemond[974129]: 2026-05-21 22:09:16.804 [Info] (Process)                                         (env: LLAMA_ARG_FLASH_ATTN)
    May 21 22:09:16 wtr lemond[974129]: 2026-05-21 22:09:16.804 [Info] (Process) to show complete usage, run with -h
    May 21 22:09:16 wtr lemond[974129]: 2026-05-21 22:09:16.852 [Error] (WrappedServer) llama-server process has terminated with exit code: 1

Inspect running environment to confirm:

    > sudo cat /proc/(systemctl show -p MainPID --value lemond)/environ | tr '\0' '\n' | grep LEMONADE_LLAMACPP_ARGS
    LEMONADE_LLAMACPP_ARGS=--flash-attn

Generated `systemd` configuration shows argument as present, but not quoted:

    > sed -n '18p;18q' /etc/systemd/system/lemond.service
    Environment=LEMONADE_LLAMACPP_ARGS=--flash-attn on

[Docs on Environments with spaces shows quoting](https://www.freedesktop.org/software/systemd/man/latest/systemd.exec.html#Environment=)

## Fix

The idiomatic Nix fix is to use an `attrset` instead of raw `Environment=` lines so that they are quoted automatically.

    > rg LEMONADE_LLAMACPP_ARGS /etc/systemd/system/lemond.service
    9:Environment="LEMONADE_LLAMACPP_ARGS=--flash-attn on"

And reflected in running env:

    > sudo cat /proc/(systemctl show -p MainPID --value lemond)/environ | tr '\0' '\n' | grep LEMONADE_LLAMACPP_ARGS
    LEMONADE_LLAMACPP_ARGS=--flash-attn on

And `llama-server` works. 🥳 

LMK if you want any tweaks, tried to follow your existing patterns.

Thanks again!