### PR TITLE
ci(update): track MTP override against Lemonade's pinned llama.cpp

### DIFF
--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -107,8 +107,14 @@ jobs:
             BODY+="$NIXPKGS_DIFFS"
           fi
 
+          if [ "${{ steps.check.outputs.mtp_override_needs_update }}" = "true" ]; then
+            BODY+=$'\n'"### ⚠️ MTP override needs hand-bump"$'\n'
+            BODY+="Lemonade v${{ steps.check.outputs.lem_latest }} pins \`llamacpp.vulkan = b${{ steps.check.outputs.mtp_required }}\`, but \`llamaCppMtpOverride\` in \`flake.nix\` is at \`b${{ steps.check.outputs.mtp_current }}\`."$'\n'
+            BODY+="Update \`version\`, \`rev\` (commit for tag \`b${{ steps.check.outputs.mtp_required }}\` in \`ggml-org/llama.cpp\`), and both hashes in the \`llamaCppMtpSrc\` / \`llamaCppMtpOverride\` blocks."$'\n'
+          fi
+
           if [ "${{ steps.check.outputs.mtp_cleanup }}" = "true" ]; then
-            BODY+=$'\n'"**TODO:** drop \`llamaCppMtpOverride\` from \`flake.nix\` — nixpkgs llama-cpp has caught up past b9175."$'\n'
+            BODY+=$'\n'"**TODO:** drop \`llamaCppMtpOverride\` from \`flake.nix\` — nixpkgs llama-cpp has caught up to b${{ steps.check.outputs.mtp_required }} (what Lemonade pins)."$'\n'
           fi
 
           if [ "${{ steps.flake_check.outputs.status }}" = "fail" ]; then

--- a/scripts/check-updates.sh
+++ b/scripts/check-updates.sh
@@ -41,13 +41,33 @@ if [ "$NIXPKGS_CURRENT_REV" != "$NIXPKGS_LATEST_REV" ]; then
   done
 fi
 
-# Drop flake.nix llamaCppMtpOverride once nixpkgs llama-cpp catches up past
-# b9175 (the MTP merge build).
+# Cross-check llamaCppMtpOverride against what Lemonade actually ships against.
+# Lemonade pins its backend versions in src/cpp/resources/backend_versions.json;
+# our flake.nix override must match `llamacpp.vulkan` for MTP to light up.
+#
+#   mtp_override_needs_update: Lemonade-required != what our flake currently pins
+#                              → human must hand-bump version/rev/hash in flake.nix.
+#   mtp_cleanup:               nixpkgs llama-cpp >= Lemonade-required
+#                              → can drop the override entirely.
+MTP_OVERRIDE_NEEDS_UPDATE=false
 MTP_CLEANUP=false
+MTP_REQUIRED=""
+MTP_CURRENT=""
 if grep -q "llamaCppMtpOverride" flake.nix; then
+  MTP_CURRENT=$(grep -A1 'LLAMA_BUILD_NUMBER' flake.nix | grep 'version =' | sed 's/.*"\([0-9]*\)".*/\1/')
+  MTP_REQUIRED=$(gh api "repos/lemonade-sdk/lemonade/contents/src/cpp/resources/backend_versions.json?ref=v${LEM_LATEST}" \
+    -H "Accept: application/vnd.github.v3.raw" \
+    --jq '.llamacpp.vulkan' 2>/dev/null | sed 's/^b//')
+
+  if [ -n "$MTP_REQUIRED" ] && [ -n "$MTP_CURRENT" ] && [ "$MTP_REQUIRED" != "$MTP_CURRENT" ]; then
+    MTP_OVERRIDE_NEEDS_UPDATE=true
+    NEEDS_UPDATE=true
+    echo "MTP override: b${MTP_CURRENT} -> b${MTP_REQUIRED} (lemonade v${LEM_LATEST} pins llamacpp.vulkan)"
+  fi
+
   llamacpp_new=$(nix eval --raw "github:NixOS/nixpkgs/${NIXPKGS_LATEST_REV}#llama-cpp-rocm.version" 2>/dev/null || echo "")
   llamacpp_num="${llamacpp_new%%-*}"
-  if [[ "$llamacpp_num" =~ ^[0-9]+$ ]] && [ "$llamacpp_num" -ge 9175 ]; then
+  if [ -n "$MTP_REQUIRED" ] && [[ "$llamacpp_num" =~ ^[0-9]+$ ]] && [ "$llamacpp_num" -ge "$MTP_REQUIRED" ]; then
     MTP_CLEANUP=true
   fi
 fi
@@ -63,6 +83,9 @@ if [ -n "${GITHUB_OUTPUT:-}" ]; then
     echo "needs_update=$NEEDS_UPDATE"
     echo "nixpkgs_needs_update=$NIXPKGS_NEEDS_UPDATE"
     echo "mtp_cleanup=$MTP_CLEANUP"
+    echo "mtp_override_needs_update=$MTP_OVERRIDE_NEEDS_UPDATE"
+    echo "mtp_required=$MTP_REQUIRED"
+    echo "mtp_current=$MTP_CURRENT"
     # Multi-line outputs need the heredoc form (GitHub Actions docs).
     echo "nixpkgs_backend_diffs<<NIXPKGS_EOF"
     printf '%s' "$NIXPKGS_BACKEND_DIFFS"

--- a/scripts/check-updates.sh
+++ b/scripts/check-updates.sh
@@ -41,14 +41,9 @@ if [ "$NIXPKGS_CURRENT_REV" != "$NIXPKGS_LATEST_REV" ]; then
   done
 fi
 
-# Cross-check llamaCppMtpOverride against what Lemonade actually ships against.
-# Lemonade pins its backend versions in src/cpp/resources/backend_versions.json;
-# our flake.nix override must match `llamacpp.vulkan` for MTP to light up.
-#
-#   mtp_override_needs_update: Lemonade-required != what our flake currently pins
-#                              → human must hand-bump version/rev/hash in flake.nix.
-#   mtp_cleanup:               nixpkgs llama-cpp >= Lemonade-required
-#                              → can drop the override entirely.
+# Cross-check llamaCppMtpOverride against Lemonade's backend_versions.json
+# (llamacpp.vulkan). Our flake pin must match for MTP to light up; nixpkgs
+# catching up to that pin means we can drop the override entirely.
 MTP_OVERRIDE_NEEDS_UPDATE=false
 MTP_CLEANUP=false
 MTP_REQUIRED=""


### PR DESCRIPTION
Followup to #12. Closes the blind spot we discovered while reviewing Lemonade 10.5.1 → 10.6.0: the workflow couldn't see that bumping Lemonade also requires a hand-bump of `llamaCppMtpOverride` in `flake.nix`.

## What was wrong

The old `mtp_cleanup` heuristic in `check-updates.sh` checked whether nixpkgs's llama-cpp was at `>= b9175` (the upstream MTP merge boundary) and would yell "drop the override." That conflates two different things:

- **MTP merged upstream** (b9175) — a fixed historical point
- **What Lemonade actually pins** (currently b9253 for vulkan/cpu, b9247 for rocm-stable) — moves with each Lemonade release

At the next nixpkgs catch-up, nixpkgs llama-cpp is at **b9190** — past 9175, so the old heuristic would (incorrectly) say cleanup-ready, even though Lemonade now needs b9253.

## What changed

`scripts/check-updates.sh`:
- Fetches Lemonade's `src/cpp/resources/backend_versions.json` at the latest release tag, parses `llamacpp.vulkan`, strips the `b` prefix.
- Reads the current pin from `flake.nix`'s `llamaCppMtpOverride` block.
- New output **`mtp_override_needs_update`**: true when our pin ≠ Lemonade's pin → human must hand-edit `flake.nix`.
- Existing **`mtp_cleanup`**: now compares nixpkgs against the Lemonade-required version, not a hardcoded b9175.
- Also forces `needs_update=true` when the MTP override drifts, so the workflow runs the rest of its pipeline even if Lemonade itself hasn't moved.

`.github/workflows/update.yml`:
- New conditional section in the PR body: **`### ⚠️ MTP override needs hand-bump`** spelling out what to edit (`version`, `rev`, both hashes in `llamaCppMtpSrc` / `llamaCppMtpOverride`).
- The existing cleanup-nag text now uses the dynamic threshold (`caught up to b${mtp_required}`) instead of the hardcoded `b9175`.

## What's deliberately not in scope

Auto-bumping the override (resolve `bXXXX` → commit SHA, rewrite `flake.nix`, prefetch both hashes) — that's a bigger change with two new hash-prefetch failure modes, deferred until we want it.

## Validation

- `shellcheck scripts/check-updates.sh` → clean.
- `actionlint .github/workflows/update.yml` → clean.
- YAML parses (`yq-go`).
- Smoke-tested locally; output on current main:
  ```
  MTP override: b9213 -> b9253 (lemonade v10.6.0 pins llamacpp.vulkan)
  ...
  needs_update=true
  mtp_cleanup=false
  mtp_override_needs_update=true
  mtp_required=9253
  mtp_current=9213
  ```
  `mtp_cleanup=false` is correct: nixpkgs llama-cpp is at b9190 < required b9253. The old heuristic would have said `true` here.