### PR TITLE
ci(release): content-gate releases, suffix same-day re-cuts, name by version

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -34,22 +34,44 @@ jobs:
       - uses: actions/checkout@v6
         with:
           fetch-depth: 0
+          fetch-tags: true
       - name: Tag and release
         env:
           GH_TOKEN: ${{ github.token }}
+          BEFORE: ${{ github.event.before }}
+          SHA: ${{ github.sha }}
         run: |
-          tag="v$(date -u +%Y.%m.%d)"
-          if git rev-parse "$tag" >/dev/null 2>&1; then
-            echo "Tag $tag already exists, nothing to do."
+          # Only release when the package set changed — skip CI/docs-only pushes.
+          changed=$(git diff --name-only "$BEFORE" "$SHA" 2>/dev/null || git show --name-only --format= "$SHA")
+          if ! echo "$changed" | grep -qE '^(flake\.(lock|nix)|pkgs/)'; then
+            echo "No package changes in this push; skipping release."
             exit 0
           fi
+
+          # First free vYYYY.MM.DD[-N] tag, so same-day re-cuts suffix instead of
+          # silently skipping (the old behaviour stranded later merges).
+          base="v$(date -u +%Y.%m.%d)"
+          tag="$base"
+          n=1
+          while git rev-parse "$tag" >/dev/null 2>&1; do
+            n=$((n + 1))
+            tag="${base}-${n}"
+          done
+
           prev_tag=$(git describe --tags --abbrev=0 2>/dev/null || true)
           if [ -n "$prev_tag" ]; then
-            range="${prev_tag}..HEAD"
-            notes=$(git log --pretty='* %s (%h)' "$range")
+            notes=$(git log --pretty='* %s (%h)' "${prev_tag}..HEAD")
           else
             notes="First tagged release."
           fi
-          git tag "$tag" "${{ github.sha }}"
+
+          lem=$(grep 'version = ' pkgs/lemonade/default.nix | head -1 | sed 's/.*"\(.*\)".*/\1/')
+          if [ -n "$lem" ]; then
+            title="$tag — Lemonade $lem"
+          else
+            title="$tag"
+          fi
+
+          git tag "$tag" "$SHA"
           git push origin "$tag"
-          printf '%s\n' "$notes" | gh release create "$tag" --title "$tag" --notes-file -
+          printf '%s\n' "$notes" | gh release create "$tag" --title "$title" --notes-file -


### PR DESCRIPTION
Fixes the release-method flaws we hit when the Lemonade 10.6.0 bump (#14) merged but got no release — the date-tag was already taken by an earlier same-day merge, so the job silently bailed.

## Problems with the old `release` job
1. **One release per day, silent skip.** `if tag exists: exit 0` — the 2nd+ merge of any day shipped nothing and said nothing.
2. **Every push tried to release**, including CI/docs-only commits (#12, #13 were workflow-only).
3. **Date tags carried no meaning** for a repo whose whole job is tracking upstream versions.

## Changes
- **Content-gated**: release only when `flake.lock`, `flake.nix`, or `pkgs/**` changed in the push (`git diff --name-only BEFORE SHA`, with a `git show` fallback for the zero-sha edge). CI/docs/scripts-only pushes no longer cut empty releases.
- **Collision suffix**: same-day re-cut picks the first free `vYYYY.MM.DD[-N]` (e.g. `v2026.05.24-2`). No silent skip, and crucially **no tag-moving** — published tags stay immutable.
- **Meaningful title**: `v2026.05.24 — Lemonade 10.6.0`, matching the earlier convention; falls back to the bare tag if the version can't be read.
- `BEFORE`/`SHA` passed via env (not `${{ }}` inline) to avoid bash-quoting hazards; added `fetch-tags: true` so the collision check sees existing tags.

## Validation
- `actionlint` clean, YAML parses.
- Unit-tested all three logic pieces locally:
  - gate: `pkgs/lemonade/default.nix` / `flake.nix` → release; `.github`+`scripts`+`docs`+`README` → skip
  - suffix loop: base taken → `-2`, base+`-2` taken → `-3`
  - title extraction → `10.6.0`

## Out of scope
The build job (build + cachix push on every push/PR) is unchanged — only the `release` job is gated.