### PR TITLE
fix(benchmark): make --mtp-ab decode A/B reliable

### DIFF
--- a/pkgs/benchmark/benchmark.py
+++ b/pkgs/benchmark/benchmark.py
@@ -212,6 +212,9 @@ def build_llama_server_args(
         "--n-gpu-layers", str(n_gpu_layers),
         "--ctx-size", str(ctx_size),
         "--parallel", "1",
+        # Match lemonade's serving config; without it the KV cache for
+        # large ctx overflows the iGPU budget and silently CPU-offloads.
+        "--flash-attn", "on",
     ]
     # --spec-draft-n-max only applies when speculative decoding is on.
     # Upstream recommends 6 for MTP; default is conservative.
@@ -493,9 +496,30 @@ def build_mtp_prompt(prompt_tokens):
     return out[:target_chars]
 
 
+def build_completion_payload(
+    model_id, prompt, gen_tokens, ignore_eos=False
+):
+    """Build the JSON body for a streaming /completions request.
+
+    With ignore_eos=True the server keeps generating until max_tokens
+    regardless of EOS. Required for the MTP A/B decode measurement:
+    otherwise a stochastic immediate-EOS produces a 1-token (empty
+    text) completion that scores as a zero-token failure.
+    """
+    payload = {
+        "model": model_id,
+        "prompt": prompt,
+        "max_tokens": gen_tokens,
+        "stream": True,
+    }
+    if ignore_eos:
+        payload["ignore_eos"] = True
+    return payload
+
+
 def run_completion(
     base_url, model_id, prompt, gen_tokens,
-    completions_path="/api/v1/completions",
+    completions_path="/api/v1/completions", ignore_eos=False,
 ):
     """Run one streaming completion.
 
@@ -505,12 +529,9 @@ def run_completion(
 
     Returns (ttft_sec, decode_tps, total_tokens_generated).
     """
-    payload = {
-        "model": model_id,
-        "prompt": prompt,
-        "max_tokens": gen_tokens,
-        "stream": True,
-    }
+    payload = build_completion_payload(
+        model_id, prompt, gen_tokens, ignore_eos=ignore_eos
+    )
 
     t_start = time.monotonic()
     t_first_token = None
@@ -709,14 +730,14 @@ def _measure_one_spec(server, prompt_tokens, gen_tokens, warmup, repeat):
     for _ in range(warmup):
         run_completion(
             server.base_url, "default", prompt, gen_tokens,
-            completions_path="/v1/completions",
+            completions_path="/v1/completions", ignore_eos=True,
         )
 
     tps_samples = []
     for i in range(repeat):
         _ttft, tps, ntok = run_completion(
             server.base_url, "default", prompt, gen_tokens,
-            completions_path="/v1/completions",
+            completions_path="/v1/completions", ignore_eos=True,
         )
         if tps is None:
             print(
@@ -806,7 +827,9 @@ def run_mtp_ab(
             argv = build_llama_server_args(
                 bin_path=bin_path, gguf=gguf, port=port,
                 device=device, spec_type=spec_type,
-                n_gpu_layers=99, ctx_size=4096,
+                # ctx sized to the 512+128-token A/B workload with
+                # headroom; 4096 wastes KV memory and risks offload.
+                n_gpu_layers=99, ctx_size=2048,
             )
             try:
                 with LlamaServer(argv, port) as server:

--- a/pkgs/benchmark/tests/test_benchmark.py
+++ b/pkgs/benchmark/tests/test_benchmark.py
@@ -185,6 +185,7 @@ class BuildLlamaServerArgsTests(unittest.TestCase):
             ("--n-gpu-layers", "99"),
             ("--ctx-size", "4096"),
             ("--parallel", "1"),
+            ("--flash-attn", "on"),
             ("--spec-draft-n-max", "6"),
         ]
         for flag, value in expected_pairs:
@@ -207,6 +208,10 @@ class BuildLlamaServerArgsTests(unittest.TestCase):
         )
         self.assertIn("--spec-type", args)
         self.assertIn("none", args)
+        # --flash-attn matches lemonade's serving config; applies
+        # regardless of spec_type.
+        idx = args.index("--flash-attn")
+        self.assertEqual(args[idx + 1], "on")
         # --spec-draft-n-max is only relevant when speculative decoding
         # is on; should be absent for spec_type='none'.
         self.assertNotIn("--spec-draft-n-max", args)
@@ -264,6 +269,28 @@ class BuildMtpPromptTests(unittest.TestCase):
         prompt = benchmark.build_mtp_prompt(100)
         self.assertGreater(len(prompt), 300)
         self.assertLess(len(prompt), 500)
+
+
+class BuildCompletionPayloadTests(unittest.TestCase):
+    def test_basic_payload(self):
+        p = benchmark.build_completion_payload("m", "hello", 64)
+        self.assertEqual(p["model"], "m")
+        self.assertEqual(p["prompt"], "hello")
+        self.assertEqual(p["max_tokens"], 64)
+        self.assertTrue(p["stream"])
+
+    def test_ignore_eos_absent_by_default(self):
+        # Lemonade path measures natural decode; must not force tokens.
+        p = benchmark.build_completion_payload("m", "hello", 64)
+        self.assertNotIn("ignore_eos", p)
+
+    def test_ignore_eos_forces_fixed_token_count(self):
+        # MTP A/B needs every iteration to emit exactly max_tokens, or
+        # a stochastic immediate-EOS yields a zero-token sample.
+        p = benchmark.build_completion_payload(
+            "m", "hello", 64, ignore_eos=True
+        )
+        self.assertTrue(p["ignore_eos"])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Problem

The `--mtp-ab` sweep produced unusable data: ~25% of iterations reported `no tokens received`, and decode was depressed by silent CPU offload. Root-caused to three independent defects — all in how the raw llama-server is driven, vs how lemonade actually serves the same model.

## Root cause: stochastic immediate-EOS

The headline failure was **not** a crash, VRAM contention, or pipe deadlock (all ruled out by reproduction). Captured SSE on a failing request:

```json
{"choices":[{"text":"","finish_reason":"stop"}], "usage":{"completion_tokens":1, ...}}
```

The model emits **EOS as its first generated token** after the repetitive MTP prompt → a 1-token, empty-text completion that scored as a zero-token failure. A decode-throughput benchmark must force a fixed token count, exactly as `llama-bench` does.

## Changes

- **`ignore_eos: true`** on the MTP path via a new tested `build_completion_payload` helper. Lemonade path unchanged (defaults to `false`).
- **`--flash-attn on`** in `build_llama_server_args` — matches lemonade's serving config; absence bloats the KV cache and triggers CPU offload.
- **ctx 4096 → 2048** — sized to the 512+128-token A/B workload.

## Verification

- Full rocm+vulkan sweep now runs **12/12 clean iterations** (was ~6/11).
- `ignore_eos` fix independently confirmed: 8/8 full completions in isolated repro.
- **28 unit tests green** (3 new for `build_completion_payload`, 1 for the flash-attn flag).

## Out of scope

Published MTP-speedup numbers — deferred to an authoritative run on AC power with an idle GPU (battery + TLP powersave governor deflated the provisional measurements).