### PR TITLE
feat(module): add enableNPU gate for GPU-only hosts (RDNA3 iGPUs / Hawk Point)

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,8 @@ inputs.nix-amd-ai.url = "github:noamsto/nix-amd-ai";
 
   hardware.amd-npu = {
     enable = true;
-    enableFastFlowLM = true;  # LLM inference on NPU
+    enableNPU = true;         # default; set false for GPU-only hosts (see "Other hardware")
+    enableFastFlowLM = true;  # LLM inference on NPU (requires enableNPU)
     enableLemonade = true;    # OpenAI-compatible API server
     enableROCm = true;        # ROCm GPU backends (llamacpp + sd-cpp)
     enableVulkan = true;      # Vulkan GPU backends (llamacpp + whispercpp)
@@ -84,9 +85,33 @@ inputs.nix-amd-ai.url = "github:noamsto/nix-amd-ai";
 
 ## Requirements
 
-- NixOS with kernel >= 6.14 (has `amdxdna` driver built-in)
-- AMD Ryzen AI processor with XDNA 2 NPU (Strix Point / Strix Halo)
+- NixOS with kernel >= 6.14 (has `amdxdna` driver built-in) — only required when `enableNPU = true`
+- AMD Ryzen AI processor with XDNA 2 NPU (Strix Point / Strix Halo) for the NPU path; the GPU backends run on any supported AMD GPU with `enableNPU = false` (see "Other hardware")
 - User in `video` and `render` groups
+
+## Other hardware (RDNA3 iGPUs / Hawk Point)
+
+The module splits into an NPU half and a GPU half. The NPU half (XRT + `amdxdna` + FastFlowLM) is built and tested for **XDNA 2** (Strix Point / Strix Halo) — that's what FastFlowLM targets. The GPU backends are independent and run on other AMD GPUs.
+
+Set `enableNPU = false` to drop the XRT/`amdxdna` closure (kernel module, IOMMU param, udev rules, memlock limits) and run GPU-only. Example for a **Hawk Point** APU (Ryzen 9 8945HS, Radeon 780M / `gfx1103`):
+
+```nix
+hardware.amd-npu = {
+  enable = true;
+  enableNPU = false;        # no XDNA-2 NPU on Hawk Point
+  enableVulkan = true;      # 780M via RADV — works, and fastest on these iGPUs
+  enableLemonade = true;
+  lemonade.user = "youruser";
+};
+```
+
+- **Vulkan** is the recommended path: RADV is arch-agnostic, so llama.cpp / whisper.cpp run on any RDNA3 iGPU including the Radeon 780M (Phoenix / Hawk Point).
+- **NPU** (`enableFastFlowLM`) is XDNA-2 only; the assertion blocks it unless `enableNPU = true`.
+- **ROCm** (`enableROCm`) is **untested on `gfx1103`** — it isn't an officially supported ROCm target and the prebuilt `llama-cpp-rocm` may not include `gfx1103` kernels. To experiment, force the arch override out-of-band; this is unsupported and may not work:
+
+  ```nix
+  systemd.services.lemond.environment.HSA_OVERRIDE_GFX_VERSION = "11.0.0";
+  ```
 
 ## What the module configures
 

--- a/README.md
+++ b/README.md
@@ -126,6 +126,12 @@ If `lemonade backends` reports a backend as `installed` but benchmarks report <5
 
 WebKitGTK suspends the network process for windows that are minimized, hidden, or moved to another workspace. That kills the SSE progress stream lemond uses for downloads at ~60–90 s. Without our patch, that nuked the whole download mid-flight. With the patch, the download keeps running server-side and finishes regardless — but the UI stops seeing progress until you refocus the window (and may need a refresh to pick up the result). For very large pulls, prefer the regular browser at `http://localhost:13305` or `lemonade pull <model>` from the CLI; both survive backgrounding cleanly.
 
+## Troubleshooting
+
+### `amdxdna ... aie2_get_info: Not supported request parameter N` in dmesg/journald
+
+Harmless. `aie2_get_info` handles the NPU's `GET_INFO` ioctl, and the mainline `amdxdna` driver implements only a subset of query types (AIE status/version/metadata, clock, hw-contexts). When userspace (`xrt-smi`, a system monitor, or the lemonade/FastFlowLM init path) probes a power/sensor/telemetry param the driver doesn't implement yet, it returns `-EOPNOTSUPP` and logs that `*ERROR*` line — often on a timer, so it repeats. NPU inference is unaffected. Upstream is filling in the missing queries (power reporting ~Linux 7.1, hwmon exposure tracked in [xdna-driver#323](https://github.com/amd/xdna-driver/issues/323)); a newer kernel makes the line disappear.
+
 ## GAIA agent framework
 
 [AMD GAIA](https://github.com/amd/gaia) is a Python agent framework that uses lemond as its inference backend (Email Triage / Code / Jira / Blender / RAG / MCP agents, plus a built-in web UI). Upstream targets pip / electron installers, neither of which fits a NixOS host cleanly, and the Python dependency tree is large and fast-moving (weekly-ish releases, torch + transformers + ~60 transitive deps). The flake therefore ships a thin `uvx` wrapper rather than a from-source Nix build:

--- a/modules/amd-npu.nix
+++ b/modules/amd-npu.nix
@@ -4,7 +4,7 @@
   pkgs,
   ...
 }: let
-  inherit (lib) mkEnableOption mkOption mkIf types optionalString optional optionals optionalAttrs makeBinPath versionAtLeast;
+  inherit (lib) mkEnableOption mkOption mkIf types optionalString optional optionals optionalAttrs makeBinPath versionAtLeast concatStringsSep;
   cfg = config.hardware.amd-npu;
 
   xrtPrefix = "${pkgs.xrt}/opt/xilinx/xrt";
@@ -16,16 +16,29 @@
     ln -sf ${pkgs.xrt-plugin-amdxdna}/opt/xilinx/xrt/lib/libxrt_driver_xdna* $out/lib/
   '';
 
-  optionalROCmLibs =
-    optionalString cfg.enableROCm
-    ":${pkgs.rocmPackages.clr}/lib";
+  # XRT (NPU) libs only present when enableNPU; ROCm libs trail them.
+  ldLibraryPath = concatStringsSep ":" (
+    optional cfg.enableNPU "${xrt-combined}/lib"
+    ++ optional cfg.enableROCm "${pkgs.rocmPackages.clr}/lib"
+  );
 
   pathList =
-    [xrt-combined]
+    optional cfg.enableNPU xrt-combined
     ++ optional cfg.enableFastFlowLM pkgs.fastflowlm;
 in {
   options.hardware.amd-npu = {
     enable = mkEnableOption "AMD NPU (AI Engine) support";
+
+    enableNPU = mkOption {
+      type = types.bool;
+      default = true;
+      description = ''
+        Whether to wire the XDNA-2 NPU stack (amdxdna kernel module, XRT,
+        IOMMU/udev/memlock). Set false for GPU-only hosts — e.g. RDNA3 iGPUs
+        (Radeon 780M / Phoenix / Hawk Point) that lack an XDNA-2 NPU — to keep
+        the Vulkan/ROCm backends without pulling in the XRT closure.
+      '';
+    };
 
     enableFastFlowLM = mkOption {
       type = types.bool;
@@ -92,25 +105,29 @@ in {
   config = mkIf cfg.enable {
     assertions = [
       {
-        assertion = versionAtLeast config.boot.kernelPackages.kernel.version "6.14";
+        assertion = !cfg.enableNPU || versionAtLeast config.boot.kernelPackages.kernel.version "6.14";
         message = "AMD NPU (amdxdna) requires kernel >= 6.14.";
+      }
+      {
+        assertion = !cfg.enableFastFlowLM || cfg.enableNPU;
+        message = "hardware.amd-npu.enableFastFlowLM requires enableNPU = true (FastFlowLM runs on the NPU).";
       }
     ];
 
-    # Kernel configuration
-    boot.kernelParams = ["iommu.passthrough=0"];
-    boot.kernelModules = ["amdxdna"];
+    # Kernel configuration (NPU-only)
+    boot.kernelParams = optionals cfg.enableNPU ["iommu.passthrough=0"];
+    boot.kernelModules = optionals cfg.enableNPU ["amdxdna"];
 
     # Udev rules for NPU device access
-    services.udev.extraRules = ''
+    services.udev.extraRules = optionalString cfg.enableNPU ''
       # AMD NPU (amdxdna) — accel subsystem
       SUBSYSTEM=="accel", DRIVERS=="amdxdna", GROUP="video", MODE="0660"
       # AMD NPU — misc device fallback
       KERNEL=="accel*", SUBSYSTEM=="misc", ATTRS{driver}=="amdxdna", GROUP="video", MODE="0660"
     '';
 
-    # PAM limits — unlimited memlock for video and render groups
-    security.pam.loginLimits = [
+    # PAM limits — unlimited memlock for NPU buffer allocation (video/render groups)
+    security.pam.loginLimits = optionals cfg.enableNPU [
       {
         domain = "@video";
         type = "-";
@@ -127,7 +144,7 @@ in {
 
     # Environment variables for XRT plugin discovery
     environment.sessionVariables =
-      {
+      optionalAttrs cfg.enableNPU {
         XILINX_XRT = "${xrt-combined}";
         XRT_PATH = "${xrt-combined}";
       }
@@ -173,10 +190,10 @@ in {
     # binaries.
     environment.systemPackages =
       [
-        xrt-combined
         pkgs.pciutils
         pkgs.lshw
       ]
+      ++ optional cfg.enableNPU xrt-combined
       ++ optional cfg.enableFastFlowLM pkgs.fastflowlm
       ++ optional cfg.enableLemonade pkgs.lemonade
       ++ optional cfg.enableROCm pkgs.rocmPackages.clr
@@ -201,9 +218,6 @@ in {
       path = pathList ++ ["/run/current-system/sw"];
       environment =
         {
-          XILINX_XRT = "${xrt-combined}";
-          XRT_PATH = "${xrt-combined}";
-          LD_LIBRARY_PATH = "${xrt-combined}/lib${optionalROCmLibs}";
           # Disable lemond's 300s upstream timeout so long prompt-processing
           # phases (common with large agent system prompts on iGPU) don't
           # abort before the first token. See lemonade-sdk/lemonade#1364.
@@ -211,17 +225,29 @@ in {
           LEMONADE_LLAMACPP_CPU_BIN = "${pkgs.llama-cpp}/bin/llama-server";
           LEMONADE_WHISPERCPP_CPU_BIN = "${pkgs.whisper-cpp}/bin/whisper-server";
           LEMONADE_LLAMACPP_ARGS = "--flash-attn ${cfg.lemonade.flashAttn}";
-        } // optionalAttrs cfg.enableImageGen {
+        }
+        // optionalAttrs cfg.enableNPU {
+          XILINX_XRT = "${xrt-combined}";
+          XRT_PATH = "${xrt-combined}";
+        }
+        // optionalAttrs (ldLibraryPath != "") {
+          LD_LIBRARY_PATH = ldLibraryPath;
+        }
+        // optionalAttrs cfg.enableImageGen {
           LEMONADE_SDCPP_CPU_BIN = "${pkgs.stable-diffusion-cpp}/bin/sd-server";
-        } // optionalAttrs cfg.enableROCm {
+        }
+        // optionalAttrs cfg.enableROCm {
           LEMONADE_LLAMACPP_ROCM_BIN = "${pkgs.llama-cpp-rocm}/bin/llama-server";
           LEMONADE_GGML_HIP_PATH = "${pkgs.llama-cpp-rocm}/lib/libggml-hip.so";
-        } // optionalAttrs (cfg.enableROCm && cfg.enableImageGen) {
+        }
+        // optionalAttrs (cfg.enableROCm && cfg.enableImageGen) {
           LEMONADE_SDCPP_ROCM_BIN = "${pkgs.stable-diffusion-cpp-rocm}/bin/sd-server";
-        } // optionalAttrs cfg.enableVulkan {
+        }
+        // optionalAttrs cfg.enableVulkan {
           LEMONADE_LLAMACPP_VULKAN_BIN = "${pkgs.llama-cpp-vulkan}/bin/llama-server";
           LEMONADE_WHISPERCPP_VULKAN_BIN = "${pkgs.whisper-cpp-vulkan}/bin/whisper-server";
-        } // optionalAttrs cfg.enableFastFlowLM {
+        }
+        // optionalAttrs cfg.enableFastFlowLM {
           # Suppress FLM's auto-update probe in the lemond-spawned subprocess.
           # New in FLM 0.9.41.
           FLM_DISABLE_UPDATE_CHECK = "1";


### PR DESCRIPTION
Closes #22.

## Summary

The module gated everything behind `hardware.amd-npu.enable`, which unconditionally pulled in the XRT/`amdxdna` closure. Hosts without an XDNA-2 NPU — e.g. RDNA3 iGPUs like the Radeon 780M on Phoenix / Hawk Point (Ryzen 9 8945HS) — could use the GPU backends but had no way to drop the unusable NPU stack, and nothing documented that the GPU half works there.

This adds an `enableNPU` option (default `true`, so existing configs are unchanged) that gates the XDNA-2/XRT-specific config: `amdxdna` kernel module, `iommu.passthrough=0`, udev rules, memlock limits, the `xrt-combined` tree, `XILINX_XRT`/`XRT_PATH` env, and the XRT entries in the `lemond` service.

## Changes

- New `enableNPU` option (default `true`).
- Assertion: `enableFastFlowLM` requires `enableNPU` (FastFlowLM runs on the NPU).
- Kernel >= 6.14 assertion now only applies when `enableNPU`.
- `lemond` `LD_LIBRARY_PATH` rebuilt as a joined list — carries only the libs actually enabled, omitted when neither NPU nor ROCm is on (fixes a latent leading-colon case).
- README: 'Other hardware (RDNA3 iGPUs / Hawk Point)' section with a GPU-only example config and the ROCm `gfx1103` caveat / experimental `HSA_OVERRIDE_GFX_VERSION` escape hatch.

## Verification

Flake NixOS eval on the branch:

| Case | Result |
|---|---|
| `enableNPU = true` | `amdxdna` + XRT present — unchanged |
| `enableNPU = false` | no `amdxdna`, no XRT package/env — closure dropped |
| `enableFastFlowLM` + `enableNPU = false` | assertion fails as intended |
| GPU-only Vulkan | `lemond` has no XRT env, no `LD_LIBRARY_PATH` |
| NPU off + ROCm on | `LD_LIBRARY_PATH` = ROCm lib only, no leading colon |

Out of scope: a first-class ROCm gfx-override knob (untested on `gfx1103`; documented as a manual escape hatch only).