### PR TITLE
feat(module): opt-in GTT memory headroom + tuning docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,6 +183,39 @@ This emits `options ttm pages_limit=31457280 page_pool_size=15728640` via
 **Leave RAM headroom** — don't set `ttmSizeGiB` to your full physical RAM; the
 CPU and OS still need their share (the 120/128 example keeps a margin).
 
+## Tuning tradeoffs we don't automate
+
+### `amd_iommu=off` would kill the NPU
+
+The Strix Halo wiki suggests `amd_iommu=off` for a small memory-read speedup.
+**Do not do this on a host that uses the NPU.** amdxdna binds the NPU through
+IOMMU SVA/PASID (`iommu_sva_bind_device`, IOMMU group 25, IOMMU in *Translated*
+mode); `amd_iommu=off` or `iommu.passthrough=1` makes the bind fail
+(`*ERROR* Can not assign PASID` / `SVA get pasid failed`) and the NPU dies. The
+module already pins `iommu.passthrough=0` for this reason. `amd_iommu=off` is
+only viable on a GPU-only host that has given up XDNA.
+
+### CPU performance tuning (not implemented — pending A/B)
+
+The wiki recommends biasing the CPU to `performance` (governor + HWP boost) for
++3% memory bandwidth / +5–8% `pp512`. We don't wire this, because on a
+shared-TDP APU the tradeoff is murky:
+
+- There's **no direct CPU-governor → GPU-clock link** — the iGPU has its own
+  clock domain. Pinning CPU cores to `performance` doesn't raise GPU clocks.
+- On shared package power, forcing the CPU to max frequency **steals TDP from
+  the iGPU** during bandwidth-bound decode — a bounded, possibly net-negative
+  lever.
+- The knob actually aimed at decode is the **C-state latency floor**
+  (`/dev/cpu_dma_latency`), which keeps the fabric/memory subsystem clocked;
+  the governor is not.
+- Prefill (`pp512`) does have a CPU component, so the wiki's prefill claim is
+  plausible — for prefill, not decode.
+
+It's left out until an A/B on an idle/AC host (governor pinned `performance`)
+confirms whether the wiki's numbers reproduce on Strix Point. Tracked in
+[#19](https://github.com/noamsto/nix-amd-ai/issues/19).
+
 ## Troubleshooting
 
 ### `amdxdna ... aie2_get_info: Not supported request parameter N` in dmesg/journald

--- a/README.md
+++ b/README.md
@@ -151,6 +151,38 @@ If `lemonade backends` reports a backend as `installed` but benchmarks report <5
 
 WebKitGTK suspends the network process for windows that are minimized, hidden, or moved to another workspace. That kills the SSE progress stream lemond uses for downloads at ~60–90 s. Without our patch, that nuked the whole download mid-flight. With the patch, the download keeps running server-side and finishes regardless — but the UI stops seeing progress until you refocus the window (and may need a refresh to pick up the result). For very large pulls, prefer the regular browser at `http://localhost:13305` or `lemonade pull <model>` from the CLI; both survive backgrounding cleanly.
 
+## GPU memory headroom
+
+The iGPU draws GPU memory from the GTT pool. By default the kernel exposes
+~27 GB addressable, which covers the 17–22 GB models this flake targets on a
+64 GB Strix Point host — so **leave these options unset there; they're a no-op.**
+
+On a **128 GB Strix Halo** host you need to raise the ceiling to expose the
+large unified pool for big models. The module takes sizes in **GiB** and
+computes the `ttm` page counts for you (`pages = GiB × 262144`):
+
+```nix
+hardware.amd-npu.gpuMemory = {
+  ttmSizeGiB = 120;       # GTT pool ceiling  → ttm pages_limit
+  pagePoolSizeGiB = 60;   # pre-cached pool   → ttm page_pool_size
+};
+```
+
+This emits `options ttm pages_limit=31457280 page_pool_size=15728640` via
+`boot.extraModprobeConfig`. Recommended starting point for 128 GB:
+
+| Option | Value (128 GB) | Meaning |
+|---|---|---|
+| `ttmSizeGiB` | 120 | Hard ceiling on the GTT pool; leaves ~8 GiB for the OS/CPU. |
+| `pagePoolSizeGiB` | 60 | Pre-cached pool inside that ceiling. |
+
+> **Note:** these Halo values are guidance from the [Strix Halo wiki](https://strixhalo.wiki/AI/AI_Capabilities_Overview),
+> **not measured on a Halo host by this flake** (the development target is a
+> 64 GB Strix Point P14s). Treat them as a starting point, not a validated tune.
+
+**Leave RAM headroom** — don't set `ttmSizeGiB` to your full physical RAM; the
+CPU and OS still need their share (the 120/128 example keeps a margin).
+
 ## Troubleshooting
 
 ### `amdxdna ... aie2_get_info: Not supported request parameter N` in dmesg/journald

--- a/docs/superpowers/plans/2026-05-31-amd-gpu-memory-tuning.md
+++ b/docs/superpowers/plans/2026-05-31-amd-gpu-memory-tuning.md
@@ -1,0 +1,328 @@
+# GPU Memory Headroom + Tuning Docs Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add an opt-in, no-cost GTT memory-headroom option (`hardware.amd-npu.gpuMemory.{ttmSizeGiB,pagePoolSizeGiB}`) to the module, plus README docs for the `amd_iommu`↔NPU tradeoff and the deferred CPU-tuning A/B.
+
+**Architecture:** Two new nullable options under the existing `hardware.amd-npu` namespace. When set, they emit a single `boot.extraModprobeConfig` line (`options ttm pages_limit=… page_pool_size=…`), with the GiB→page conversion (`× 262144`) done in Nix so callers never compute page counts. Default `null` → module emits nothing → today's behavior is byte-for-byte unchanged. Two assertions keep the inputs coherent. Verification rides the flake's existing `checks.*` `nixosSystem`-eval harness.
+
+**Tech Stack:** Nix / NixOS module system, flake-parts, the flake's `checks` outputs (`nix build .#checks.x86_64-linux.<name>`).
+
+**Spec:** `docs/superpowers/specs/2026-05-31-amd-gpu-memory-tuning-design.md`
+
+---
+
+## File Structure
+
+- `modules/amd-npu.nix` — add `gpuMemory.*` options (in `options.hardware.amd-npu`), the `gttPages` helper (in the top `let`), the two assertions (append to existing `assertions` list), and the `boot.extraModprobeConfig` emission (in `config`). Single file, follows existing style.
+- `flake.nix` — add `checks.module-eval-gtt` (positive + negative grep). Follows the existing `module-eval-*` pattern.
+- `README.md` — add a "GPU memory headroom" section and a "Tuning tradeoffs we don't automate" subsection.
+
+---
+
+## Task 1: Failing check for the GTT modprobe emission
+
+**Files:**
+- Modify: `flake.nix` (add a new entry to the `checks` attrset, after `module-eval-vulkan-true`, around `flake.nix:194`)
+
+- [ ] **Step 1: Write the failing check**
+
+Add this entry inside the `checks = { … };` attrset in `flake.nix`, immediately after the `module-eval-vulkan-true` block (before the closing `};` of `checks`):
+
+```nix
+          # GTT headroom: configured system emits the ttm modprobe line with
+          # GiB→page conversion; default system emits no ttm line.
+          module-eval-gtt = let
+            mkSys = extra: (inputs.nixpkgs.lib.nixosSystem {
+              inherit system;
+              modules = [
+                inputs.self.nixosModules.default
+                {
+                  boot.loader.grub.enable = false;
+                  fileSystems."/" = { device = "/dev/sda1"; fsType = "ext4"; };
+                  hardware.amd-npu = {
+                    enable = true;
+                    lemonade.user = "testuser";
+                  } // extra;
+                  users.users.testuser = {
+                    isNormalUser = true;
+                    extraGroups = ["video" "render"];
+                  };
+                }
+              ];
+            }).config.boot.extraModprobeConfig;
+            configured = mkSys {
+              gpuMemory = { ttmSizeGiB = 120; pagePoolSizeGiB = 60; };
+            };
+            default = mkSys {};
+          in
+            pkgs.runCommand "module-eval-gtt" {
+              inherit configured default;
+            } ''
+              echo "$configured" | grep -F 'options ttm pages_limit=31457280 page_pool_size=15728640'
+              echo "$default" | grep -vq 'pages_limit' || { echo "default must not set pages_limit"; exit 1; }
+              touch $out
+            '';
+```
+
+- [ ] **Step 2: Run the check to verify it fails**
+
+Run: `nix build .#checks.x86_64-linux.module-eval-gtt -L`
+Expected: FAIL during evaluation — `error: The option 'hardware.amd-npu.gpuMemory' does not exist.` (the option isn't defined yet).
+
+- [ ] **Step 3: Commit the failing check**
+
+```bash
+git add flake.nix
+git commit -m "test(module): add failing check for gpuMemory GTT emission (#19)"
+```
+
+---
+
+## Task 2: Implement the `gpuMemory` options
+
+**Files:**
+- Modify: `modules/amd-npu.nix` — top `let` (around `:6-25`), `options.hardware.amd-npu` (around `:27-90`), `assertions` (around `:93-98`), `config` body (after the `boot.kernelParams`/`boot.kernelModules` lines, around `:101`).
+
+- [ ] **Step 1: Add the `gttPages` helper to the top `let`**
+
+In `modules/amd-npu.nix`, add this binding to the existing `let` block (e.g. right after the `cfg = config.hardware.amd-npu;` line at `:8`):
+
+```nix
+  # 4096-byte pages: pages = GiB * 1024^3 / 4096 = GiB * 262144.
+  gttPages = gib: gib * 262144;
+```
+
+- [ ] **Step 2: Add the `gpuMemory` options**
+
+Insert this option block inside `options.hardware.amd-npu = { … };`, after the `lemonade = { … };` block and before the closing `};` (around `:89`):
+
+```nix
+    gpuMemory = {
+      ttmSizeGiB = mkOption {
+        type = types.nullOr types.ints.positive;
+        default = null;
+        description = ''
+          GTT pool ceiling in GiB, emitted as the `ttm` `pages_limit` modprobe
+          option (page count is computed for you: GiB * 262144).
+
+          null (default) leaves the kernel default untouched. No-op on Strix
+          Point / 64 GB — the default (~27 GB addressable) already covers
+          17-22 GB models. This is the lever a Strix Halo / 128 GB host needs
+          to expose its large unified pool. See the README "GPU memory
+          headroom" section for recommended Halo values.
+        '';
+      };
+
+      pagePoolSizeGiB = mkOption {
+        type = types.nullOr types.ints.positive;
+        default = null;
+        description = ''
+          Pre-cached GTT pool size in GiB, emitted as the `ttm` `page_pool_size`
+          modprobe option (pages kept warm rather than freed back). Requires
+          ttmSizeGiB and must be <= it. null (default) leaves the kernel
+          default untouched.
+        '';
+      };
+    };
+```
+
+- [ ] **Step 3: Add the assertions**
+
+Append these two entries to the existing `assertions = [ … ];` list in `config` (after the kernel-version assertion, around `:97`):
+
+```nix
+      {
+        assertion = cfg.gpuMemory.pagePoolSizeGiB == null || cfg.gpuMemory.ttmSizeGiB != null;
+        message = "hardware.amd-npu.gpuMemory.pagePoolSizeGiB requires ttmSizeGiB to be set.";
+      }
+      {
+        assertion =
+          cfg.gpuMemory.pagePoolSizeGiB == null
+          || cfg.gpuMemory.ttmSizeGiB == null
+          || cfg.gpuMemory.pagePoolSizeGiB <= cfg.gpuMemory.ttmSizeGiB;
+        message = "hardware.amd-npu.gpuMemory.pagePoolSizeGiB must be <= ttmSizeGiB.";
+      }
+```
+
+- [ ] **Step 4: Emit the modprobe line**
+
+In `config`, replace the existing single-line `boot.kernelParams`/`boot.kernelModules` region:
+
+```nix
+    # Kernel configuration
+    boot.kernelParams = ["iommu.passthrough=0"];
+    boot.kernelModules = ["amdxdna"];
+```
+
+with:
+
+```nix
+    # Kernel configuration
+    boot.kernelParams = ["iommu.passthrough=0"];
+    boot.kernelModules = ["amdxdna"];
+
+    # GTT pool sizing (opt-in). Raises what's *addressable*, not consumed — no
+    # power cost. Needed on Strix Halo / 128 GB for large models; no-op on
+    # Strix Point / 64 GB. modprobe.d form matches the Strix Halo wiki verbatim.
+    boot.extraModprobeConfig = mkIf (cfg.gpuMemory.ttmSizeGiB != null) ''
+      options ttm pages_limit=${toString (gttPages cfg.gpuMemory.ttmSizeGiB)}${optionalString (cfg.gpuMemory.pagePoolSizeGiB != null) " page_pool_size=${toString (gttPages cfg.gpuMemory.pagePoolSizeGiB)}"}
+    '';
+```
+
+- [ ] **Step 5: Run the check to verify it passes**
+
+Run: `nix build .#checks.x86_64-linux.module-eval-gtt -L`
+Expected: PASS (builds `module-eval-gtt`; both greps succeed).
+
+- [ ] **Step 6: Verify the default/unset path still evaluates clean**
+
+Run: `nix build .#checks.x86_64-linux.module-eval-rocm-false -L`
+Expected: PASS (proves the new `mkIf`-gated emission doesn't perturb the options-unset configuration).
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add modules/amd-npu.nix
+git commit -m "feat(module): opt-in GTT pool sizing via gpuMemory options (#19)"
+```
+
+---
+
+## Task 3: README — GPU memory headroom section
+
+**Files:**
+- Modify: `README.md` — add a new `## GPU memory headroom` section. Place it after the "What the module configures" section and before "Troubleshooting".
+
+- [ ] **Step 1: Add the section**
+
+Insert this section into `README.md` (after the "Why the module flags matter" / module-configures material, before `## Troubleshooting`):
+
+```markdown
+## GPU memory headroom
+
+The iGPU draws GPU memory from the GTT pool. By default the kernel exposes
+~27 GB addressable, which covers the 17–22 GB models this flake targets on a
+64 GB Strix Point host — so **leave these options unset there; they're a no-op.**
+
+On a **128 GB Strix Halo** host you need to raise the ceiling to expose the
+large unified pool for big models. The module takes sizes in **GiB** and
+computes the `ttm` page counts for you (`pages = GiB × 262144`):
+
+```nix
+hardware.amd-npu.gpuMemory = {
+  ttmSizeGiB = 120;       # GTT pool ceiling  → ttm pages_limit
+  pagePoolSizeGiB = 60;   # pre-cached pool   → ttm page_pool_size
+};
+```
+
+This emits `options ttm pages_limit=31457280 page_pool_size=15728640` via
+`boot.extraModprobeConfig`. Recommended starting point for 128 GB:
+
+| Option | Value (128 GB) | Meaning |
+|---|---|---|
+| `ttmSizeGiB` | 120 | Hard ceiling on the GTT pool; leaves ~8 GiB for the OS/CPU. |
+| `pagePoolSizeGiB` | 60 | Pre-cached pool inside that ceiling. |
+
+> **Note:** these Halo values are guidance from the [Strix Halo wiki](https://strixhalo.wiki/AI/AI_Capabilities_Overview),
+> **not measured on a Halo host by this flake** (the development target is a
+> 64 GB Strix Point P14s). Treat them as a starting point, not a validated tune.
+
+**Leave RAM headroom** — don't set `ttmSizeGiB` to your full physical RAM; the
+CPU and OS still need their share (the 120/128 example keeps a margin).
+```
+
+- [ ] **Step 2: Verify it renders**
+
+Run: `grep -n "GPU memory headroom" README.md`
+Expected: one match for the new heading.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add README.md
+git commit -m "docs(readme): document opt-in GTT headroom + Halo values (#19)"
+```
+
+---
+
+## Task 4: README — tuning tradeoffs we don't automate
+
+**Files:**
+- Modify: `README.md` — add a `## Tuning tradeoffs we don't automate` section (after "GPU memory headroom", before "Troubleshooting").
+
+- [ ] **Step 1: Add the section**
+
+Insert into `README.md`:
+
+```markdown
+## Tuning tradeoffs we don't automate
+
+### `amd_iommu=off` would kill the NPU
+
+The Strix Halo wiki suggests `amd_iommu=off` for a small memory-read speedup.
+**Do not do this on a host that uses the NPU.** amdxdna binds the NPU through
+IOMMU SVA/PASID (`iommu_sva_bind_device`, IOMMU group 25, IOMMU in *Translated*
+mode); `amd_iommu=off` or `iommu.passthrough=1` makes the bind fail
+(`*ERROR* Can not assign PASID` / `SVA get pasid failed`) and the NPU dies. The
+module already pins `iommu.passthrough=0` for this reason. `amd_iommu=off` is
+only viable on a GPU-only host that has given up XDNA.
+
+### CPU performance tuning (not implemented — pending A/B)
+
+The wiki recommends biasing the CPU to `performance` (governor + HWP boost) for
++3% memory bandwidth / +5–8% `pp512`. We don't wire this, because on a
+shared-TDP APU the tradeoff is murky:
+
+- There's **no direct CPU-governor → GPU-clock link** — the iGPU has its own
+  clock domain. Pinning CPU cores to `performance` doesn't raise GPU clocks.
+- On shared package power, forcing the CPU to max frequency **steals TDP from
+  the iGPU** during bandwidth-bound decode — a bounded, possibly net-negative
+  lever.
+- The knob actually aimed at decode is the **C-state latency floor**
+  (`/dev/cpu_dma_latency`), which keeps the fabric/memory subsystem clocked;
+  the governor is not.
+- Prefill (`pp512`) does have a CPU component, so the wiki's prefill claim is
+  plausible — for prefill, not decode.
+
+It's left out until an A/B on an idle/AC host (governor pinned `performance`)
+confirms whether the wiki's numbers reproduce on Strix Point. Tracked in
+[#19](https://github.com/noamsto/nix-amd-ai/issues/19).
+```
+
+- [ ] **Step 2: Verify it renders**
+
+Run: `grep -n "Tuning tradeoffs we don't automate" README.md`
+Expected: one match.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add README.md
+git commit -m "docs(readme): document amd_iommu↔NPU + deferred CPU-tuning A/B (#19)"
+```
+
+---
+
+## Task 5: Full verification
+
+- [ ] **Step 1: Run the whole check suite**
+
+Run: `nix flake check -L`
+Expected: PASS — all `module-eval-*` checks (including the new `module-eval-gtt`) succeed; no eval errors.
+
+- [ ] **Step 2: Sanity-check the assertion fires**
+
+Temporarily add `gpuMemory.pagePoolSizeGiB = 60;` (without `ttmSizeGiB`) to the `module-eval-rocm-false` check config, then run:
+
+Run: `nix build .#checks.x86_64-linux.module-eval-rocm-false -L`
+Expected: FAIL — `Failed assertions: … pagePoolSizeGiB requires ttmSizeGiB to be set.`
+Then **revert that temporary edit** (do not commit it).
+
+---
+
+## Self-Review Notes
+
+- **Spec coverage:** ttmSizeGiB/pagePoolSizeGiB options (Task 2) ✓; GiB→page math via `gttPages` (Task 2 Step 1) ✓; `boot.extraModprobeConfig` delivery (Task 2 Step 4) ✓; assertions (Task 2 Step 3) ✓; default-null = no-op (Task 1 negative grep, Task 2 Step 6) ✓; README GPU-memory section + Halo table + un-measured caveat + RAM-headroom caveat (Task 3) ✓; README amd_iommu note (Task 4) ✓; README CPU-tuning deferred-A/B note (Task 4) ✓. `performanceMode` implementation explicitly deferred — no task, by design.
+- **Type consistency:** `gttPages`, `ttmSizeGiB`, `pagePoolSizeGiB`, `module-eval-gtt` used identically across all tasks; expected emitted string `options ttm pages_limit=31457280 page_pool_size=15728640` matches the `× 262144` math (120 → 31457280, 60 → 15728640).
+- **No placeholders:** every code/command step is concrete.

--- a/docs/superpowers/specs/2026-05-31-amd-gpu-memory-tuning-design.md
+++ b/docs/superpowers/specs/2026-05-31-amd-gpu-memory-tuning-design.md
@@ -1,0 +1,151 @@
+# Opt-in GPU memory headroom + performance-tuning docs
+
+**Issue:** [#19](https://github.com/noamsto/nix-amd-ai/issues/19)
+**Date:** 2026-05-31
+**Status:** Approved, pending implementation plan
+
+## Summary
+
+Add an **opt-in, no-cost** GPU-memory-headroom option to the `hardware.amd-npu`
+module, and document two tuning tradeoffs we deliberately do *not* automate. The
+guiding principle from the brainstorm: ship only the knobs that are *free*
+(change what's addressable, not what's consumed), and *document* the
+power-costly CPU knobs for a later A/B rather than forcing them globally.
+
+This is a deliberately narrow slice of the wiki's tuning surface. The
+power-costly CPU tuning (governor, C-state floor, THP, `vm.*`) is **out of
+scope** and deferred to a measured A/B (see "Deferred" below).
+
+## Scope
+
+Three deliverables, one explicit non-goal.
+
+### 1. `gpuMemory.ttmSizeGiB` / `pagePoolSizeGiB` (code — no-cost, static)
+
+New options under the existing `hardware.amd-npu` namespace. Both default to
+`null`, which preserves today's behavior exactly (the module emits nothing).
+
+```nix
+hardware.amd-npu.gpuMemory = {
+  ttmSizeGiB = mkOption {
+    type = types.nullOr types.ints.positive;
+    default = null;
+    description = ''
+      GTT pool ceiling in GiB, emitted as the `ttm` `pages_limit` modprobe
+      option. null (default) leaves the kernel default untouched.
+
+      No-op on Strix Point / 64 GB: the default (~27 GB addressable) already
+      covers 17-22 GB models. This is the lever a Strix Halo / 128 GB host
+      needs to expose its large unified pool for big models. See the README
+      "GPU memory headroom" section for recommended Halo values.
+
+      Page count is computed for you: pages = GiB * 262144 (= GiB * 1024^3 / 4096).
+    '';
+  };
+
+  pagePoolSizeGiB = mkOption {
+    type = types.nullOr types.ints.positive;
+    default = null;
+    description = ''
+      Pre-cached GTT pool size in GiB, emitted as the `ttm` `page_pool_size`
+      modprobe option. Pages kept warm rather than freed back to the system.
+      Must be <= ttmSizeGiB. null (default) leaves the kernel default untouched.
+    '';
+  };
+};
+```
+
+**Page-count math (exact integer arithmetic):**
+
+```
+pages = GiB * 262144     # = GiB * 1024^3 / 4096  (4096-byte pages)
+```
+
+Verified against the issue's worked examples: 120 GiB -> 31457280,
+60 GiB -> 15728640.
+
+**Delivery mechanism:** `boot.extraModprobeConfig`, emitting
+
+```
+options ttm pages_limit=<pages> page_pool_size=<pages>
+```
+
+Chosen over the `ttm.pages_limit=` kernel cmdline param because it matches the
+wiki's documented form verbatim (what users cross-reference) and is the form
+that applies when `ttm` loads as an amdgpu dependency.
+
+**Assertion:** if `pagePoolSizeGiB != null` then `ttmSizeGiB` must also be set
+and `pagePoolSizeGiB <= ttmSizeGiB` (a pool larger than its ceiling is
+nonsensical). Define the error out of existence where cheap; assert where not.
+
+### 2. README: GPU memory headroom (doc)
+
+A new section documenting the option and the recommended Strix Halo values.
+
+> **Honesty caveat to bake into the prose:** these Halo numbers are
+> wiki/community guidance, **not measured on a Halo host by this flake** (our
+> target is the 64 GB Strix Point P14s). Label them as such; do not imply
+> validation.
+
+Recommended-values table for a 128 GB Strix Halo:
+
+| Option | Wiki example (128 GB) | Meaning |
+|---|---|---|
+| `ttmSizeGiB` -> `pages_limit` | 120 | Hard ceiling on the GTT pool; leaves ~8 GiB for the OS/CPU. |
+| `pagePoolSizeGiB` -> `page_pool_size` | 60 | Pre-cached pool inside that ceiling. |
+
+Caveats in prose:
+- **Leave RAM headroom** — don't set `ttmSizeGiB` to full physical RAM; the
+  CPU/OS still need their share. The wiki's 120/128 leaves a margin.
+- **No-op on Strix Point / 64 GB** — leave both `null`; the kernel default
+  covers our model sizes. The recommendation block is for 128 GB Halo hosts.
+
+### 3. README: tuning tradeoffs we don't automate (doc)
+
+Two subsections capturing verified findings.
+
+**`amd_iommu=off` <-> NPU tradeoff.** Why we keep the IOMMU on: amdxdna binds
+the NPU via IOMMU SVA/PASID (`iommu_sva_bind_device`, IOMMU group 25, IOMMU in
+Translated mode). `amd_iommu=off` or passthrough mode kills the NPU
+(`*ERROR* Can not assign PASID` / `SVA get pasid failed`). The module already
+sets `iommu.passthrough=0` for this reason. `amd_iommu=off` is only viable on a
+GPU-only host that has given up XDNA.
+
+**CPU performance tuning (not implemented, pending A/B).** Document the
+mechanism worked out during the brainstorm:
+- No direct CPU-governor -> GPU-clock link; the iGPU has its own clock domain.
+- On shared-TDP Strix Point, forcing the CPU governor to `performance` *steals*
+  package power from the iGPU on bandwidth-bound decode — a bounded, possibly
+  net-negative lever.
+- The C-state latency floor (`/dev/cpu_dma_latency`) is the more GPU-relevant
+  knob (keeps fabric/memory clocked for bandwidth-bound decode), and the
+  cleanest to scope (held fd, auto-released on close).
+- Prefill (`pp512`) sees a small CPU benefit — matches the wiki's "+5-8% pp512"
+  (a prefill claim, not decode).
+- **Conclusion:** not implemented; blocked on an A/B on an idle/AC host with the
+  `performance` governor pinned, to confirm whether the wiki's claims reproduce
+  on Strix Point.
+
+## Deferred (explicitly NOT in this PR)
+
+- `performanceMode` / governor / C-state-floor *implementation*. Blocked on the
+  A/B test result above. Documented in the README so the follow-up isn't lost.
+- README perf-baseline refresh (ROCm closed the gap: 15.6/17.0 vs the older
+  13.9/17.5). Tracked separately; not part of this change.
+
+## Files touched
+
+- `modules/amd-npu.nix` — new `gpuMemory.*` options + `boot.extraModprobeConfig`
+  + assertion.
+- `README.md` — "GPU memory headroom" section (option + Halo table) and a
+  "tuning tradeoffs we don't automate" subsection (`amd_iommu`, CPU tuning).
+
+## Testing / verification
+
+- `nix flake check` / module evaluates with options unset (no behavior change).
+- Evaluate with `ttmSizeGiB = 120; pagePoolSizeGiB = 60;` and confirm the
+  generated `boot.extraModprobeConfig` contains
+  `options ttm pages_limit=31457280 page_pool_size=15728640`.
+- Assertion fires when `pagePoolSizeGiB > ttmSizeGiB` or when `pagePoolSizeGiB`
+  is set without `ttmSizeGiB`.
+- README renders; tables and caveats present.

--- a/flake.nix
+++ b/flake.nix
@@ -192,6 +192,40 @@
               }
             ];
           }).config.system.build.etc;
+
+          # GTT headroom: configured system emits the ttm modprobe line with
+          # GiB→page conversion; default system emits no ttm line.
+          module-eval-gtt = let
+            mkSys = extra: (inputs.nixpkgs.lib.nixosSystem {
+              inherit system;
+              modules = [
+                inputs.self.nixosModules.default
+                {
+                  boot.loader.grub.enable = false;
+                  fileSystems."/" = { device = "/dev/sda1"; fsType = "ext4"; };
+                  hardware.amd-npu = {
+                    enable = true;
+                    lemonade.user = "testuser";
+                  } // extra;
+                  users.users.testuser = {
+                    isNormalUser = true;
+                    extraGroups = ["video" "render"];
+                  };
+                }
+              ];
+            }).config.boot.extraModprobeConfig;
+            configured = mkSys {
+              gpuMemory = { ttmSizeGiB = 120; pagePoolSizeGiB = 60; };
+            };
+            default = mkSys {};
+          in
+            pkgs.runCommand "module-eval-gtt" {
+              inherit configured default;
+            } ''
+              echo "$configured" | grep -F 'options ttm pages_limit=31457280 page_pool_size=15728640'
+              echo "$default" | grep -vq 'pages_limit' || { echo "default must not set pages_limit"; exit 1; }
+              touch $out
+            '';
         };
 
         apps.benchmark = {

--- a/flake.nix
+++ b/flake.nix
@@ -217,12 +217,17 @@
             configured = mkSys {
               gpuMemory = { ttmSizeGiB = 120; pagePoolSizeGiB = 60; };
             };
+            ttmOnly = mkSys {
+              gpuMemory = { ttmSizeGiB = 10; };
+            };
             default = mkSys {};
           in
             pkgs.runCommand "module-eval-gtt" {
-              inherit configured default;
+              inherit configured ttmOnly default;
             } ''
               echo "$configured" | grep -F 'options ttm pages_limit=31457280 page_pool_size=15728640'
+              echo "$ttmOnly" | grep -F 'options ttm pages_limit=2621440'
+              echo "$ttmOnly" | grep -vq 'page_pool_size' || { echo "ttm-only must not set page_pool_size"; exit 1; }
               echo "$default" | grep -vq 'pages_limit' || { echo "default must not set pages_limit"; exit 1; }
               touch $out
             '';

--- a/modules/amd-npu.nix
+++ b/modules/amd-npu.nix
@@ -10,6 +10,11 @@
   # 4096-byte pages: pages = GiB * 1024^3 / 4096 = GiB * 262144.
   gttPages = gib: gib * 262144;
 
+  # Optional " page_pool_size=…" clause appended to the ttm modprobe line.
+  ttmPagePoolClause =
+    optionalString (cfg.gpuMemory.pagePoolSizeGiB != null)
+    " page_pool_size=${toString (gttPages cfg.gpuMemory.pagePoolSizeGiB)}";
+
   xrtPrefix = "${pkgs.xrt}/opt/xilinx/xrt";
 
   xrt-combined = pkgs.runCommand "xrt-combined" {} ''
@@ -164,7 +169,7 @@ in {
     # power cost. Needed on Strix Halo / 128 GB for large models; no-op on
     # Strix Point / 64 GB. modprobe.d form matches the Strix Halo wiki verbatim.
     boot.extraModprobeConfig = mkIf (cfg.gpuMemory.ttmSizeGiB != null) ''
-      options ttm pages_limit=${toString (gttPages cfg.gpuMemory.ttmSizeGiB)}${optionalString (cfg.gpuMemory.pagePoolSizeGiB != null) " page_pool_size=${toString (gttPages cfg.gpuMemory.pagePoolSizeGiB)}"}
+      options ttm pages_limit=${toString (gttPages cfg.gpuMemory.ttmSizeGiB)}${ttmPagePoolClause}
     '';
 
     # Udev rules for NPU device access

--- a/modules/amd-npu.nix
+++ b/modules/amd-npu.nix
@@ -7,6 +7,9 @@
   inherit (lib) mkEnableOption mkOption mkIf types optionalString optional optionals optionalAttrs makeBinPath versionAtLeast concatStringsSep;
   cfg = config.hardware.amd-npu;
 
+  # 4096-byte pages: pages = GiB * 1024^3 / 4096 = GiB * 262144.
+  gttPages = gib: gib * 262144;
+
   xrtPrefix = "${pkgs.xrt}/opt/xilinx/xrt";
 
   xrt-combined = pkgs.runCommand "xrt-combined" {} ''
@@ -100,6 +103,34 @@ in {
         '';
       };
     };
+
+    gpuMemory = {
+      ttmSizeGiB = mkOption {
+        type = types.nullOr types.ints.positive;
+        default = null;
+        description = ''
+          GTT pool ceiling in GiB, emitted as the `ttm` `pages_limit` modprobe
+          option (page count is computed for you: GiB * 262144).
+
+          null (default) leaves the kernel default untouched. No-op on Strix
+          Point / 64 GB — the default (~27 GB addressable) already covers
+          17-22 GB models. This is the lever a Strix Halo / 128 GB host needs
+          to expose its large unified pool. See the README "GPU memory
+          headroom" section for recommended Halo values.
+        '';
+      };
+
+      pagePoolSizeGiB = mkOption {
+        type = types.nullOr types.ints.positive;
+        default = null;
+        description = ''
+          Pre-cached GTT pool size in GiB, emitted as the `ttm` `page_pool_size`
+          modprobe option (pages kept warm rather than freed back). Requires
+          ttmSizeGiB and must be <= it. null (default) leaves the kernel
+          default untouched.
+        '';
+      };
+    };
   };
 
   config = mkIf cfg.enable {
@@ -112,11 +143,29 @@ in {
         assertion = !cfg.enableFastFlowLM || cfg.enableNPU;
         message = "hardware.amd-npu.enableFastFlowLM requires enableNPU = true (FastFlowLM runs on the NPU).";
       }
+      {
+        assertion = cfg.gpuMemory.pagePoolSizeGiB == null || cfg.gpuMemory.ttmSizeGiB != null;
+        message = "hardware.amd-npu.gpuMemory.pagePoolSizeGiB requires ttmSizeGiB to be set.";
+      }
+      {
+        assertion =
+          cfg.gpuMemory.pagePoolSizeGiB == null
+          || cfg.gpuMemory.ttmSizeGiB == null
+          || cfg.gpuMemory.pagePoolSizeGiB <= cfg.gpuMemory.ttmSizeGiB;
+        message = "hardware.amd-npu.gpuMemory.pagePoolSizeGiB must be <= ttmSizeGiB.";
+      }
     ];
 
     # Kernel configuration (NPU-only)
     boot.kernelParams = optionals cfg.enableNPU ["iommu.passthrough=0"];
     boot.kernelModules = optionals cfg.enableNPU ["amdxdna"];
+
+    # GTT pool sizing (opt-in). Raises what's *addressable*, not consumed — no
+    # power cost. Needed on Strix Halo / 128 GB for large models; no-op on
+    # Strix Point / 64 GB. modprobe.d form matches the Strix Halo wiki verbatim.
+    boot.extraModprobeConfig = mkIf (cfg.gpuMemory.ttmSizeGiB != null) ''
+      options ttm pages_limit=${toString (gttPages cfg.gpuMemory.ttmSizeGiB)}${optionalString (cfg.gpuMemory.pagePoolSizeGiB != null) " page_pool_size=${toString (gttPages cfg.gpuMemory.pagePoolSizeGiB)}"}
+    '';
 
     # Udev rules for NPU device access
     services.udev.extraRules = optionalString cfg.enableNPU ''


### PR DESCRIPTION
## Summary

Adds an **opt-in, no-cost** GTT GPU-memory-headroom option to `hardware.amd-npu`, plus docs for two tuning tradeoffs we deliberately don't automate. Partially addresses #19 (the GTT + `amd_iommu` items); the governor/CPU-tuning item is deliberately deferred — see below.

- **`hardware.amd-npu.gpuMemory.{ttmSizeGiB,pagePoolSizeGiB}`** — both `nullOr ints.positive`, default `null`. When set, emits `options ttm pages_limit=… page_pool_size=…` via `boot.extraModprobeConfig`. GiB→page conversion (`× 262144`) done in Nix so callers never compute page counts. Two assertions: `pagePoolSizeGiB` requires `ttmSizeGiB`, and must be `≤` it.
- **No power cost:** raises what's *addressable*, not consumed. The lever a 128 GB Strix Halo host needs for large models; a no-op on the 64 GB Strix Point dev target (left `null` ⇒ module emits nothing, prior behavior byte-for-byte unchanged).
- **README:** "GPU memory headroom" section (option + Halo recommendation table, labeled wiki-guidance-not-measured) and "Tuning tradeoffs we don't automate" (`amd_iommu=off` ↔ NPU SVA/PASID; CPU governor analysis deferred to an A/B).

## Deferred (not in this PR)
- CPU performance tuning (governor / C-state floor) — bounded/possibly net-negative on shared-TDP Strix Point; left to a measured A/B. **`Refs #19`, does not close it** — #19 stays open as the umbrella for that follow-up.

## Test Plan
- [x] `nix build .#checks.x86_64-linux.module-eval-gtt` — emits `pages_limit=31457280 page_pool_size=15728640` (120/60 GiB) and `pages_limit=2621440` with no `page_pool_size` (ttm-only)
- [x] `module-eval-rocm-false` — default/unset path unaffected
- [x] assertion fires: `pagePoolSizeGiB` without `ttmSizeGiB`
- [x] assertion fires: `pagePoolSizeGiB > ttmSizeGiB`