### PR TITLE
docs(readme): correct ROCm gfx1103 note (native kernels, no override needed)

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ hardware.amd-npu = {
 
 - **Vulkan** is the recommended path: RADV is arch-agnostic, so llama.cpp / whisper.cpp run on any RDNA3 iGPU including the Radeon 780M (Phoenix / Hawk Point).
 - **NPU** (`enableFastFlowLM`) is XDNA-2 only; the assertion blocks it unless `enableNPU = true`.
-- **ROCm** (`enableROCm`) is **untested on `gfx1103`** — it isn't an officially supported ROCm target and the prebuilt `llama-cpp-rocm` may not include `gfx1103` kernels. To experiment, force the arch override out-of-band; this is unsupported and may not work:
+- **ROCm** (`enableROCm`): the shipped `llama-cpp-rocm` is compiled with `gfx1103` in its `CMAKE_HIP_ARCHITECTURES` list, so it carries native 780M kernels — no `HSA_OVERRIDE_GFX_VERSION` workaround should be needed. This is **untested on actual Hawk Point hardware**, and rocBLAS coverage for `gfx1103` APUs can be uneven, so Vulkan remains the recommended path. If ROCm misbehaves, the usual fallback is to alias the arch to `gfx1100`:
 
   ```nix
   systemd.services.lemond.environment.HSA_OVERRIDE_GFX_VERSION = "11.0.0";


### PR DESCRIPTION
Follow-up to #23.

The 'Other hardware' ROCm bullet claimed the prebuilt `llama-cpp-rocm` may lack `gfx1103` kernels and require `HSA_OVERRIDE_GFX_VERSION=11.0.0`. That's incorrect — `llama-cpp-rocm` is compiled with `gfx1103` in its `CMAKE_HIP_ARCHITECTURES` list:

```
gfx900;...;gfx1100;gfx1101;gfx1102;gfx1103;gfx1150;gfx1151;...
```

So the binary carries native 780M kernels and no override should be needed. Reframed the bullet: native gfx1103 support, still untested on real Hawk Point hardware, Vulkan remains recommended, and the `HSA_OVERRIDE` line is now a fallback-if-rocBLAS-misbehaves rather than a prerequisite.