### PR TITLE
feat(module): opt out of the lemonade Tauri desktop app

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,6 +149,8 @@ If `lemonade backends` reports a backend as `installed` but benchmarks report <5
 
 WebKitGTK suspends the network process for windows that are minimized, hidden, or moved to another workspace. That kills the SSE progress stream lemond uses for downloads at ~60–90 s. Without our patch, that nuked the whole download mid-flight. With the patch, the download keeps running server-side and finishes regardless — but the UI stops seeing progress until you refocus the window (and may need a refresh to pick up the result). For very large pulls, prefer the regular browser at `http://localhost:13305` or `lemonade pull <model>` from the CLI; both survive backgrounding cleanly.
 
+The desktop app is the only part of lemonade that pulls a Rust + npm build (and a crates.io cargo-vendor fetch). Headless/server hosts that only need the `lemond` API + CLI can skip it entirely with `lemonade.desktopApp.enable = false;` — this drops the Tauri build path from the closure. (The pre-built app is also on the [binary cache](#binary-cache), so configuring the substituter avoids building it from source in the first place.)
+
 ## GPU memory headroom
 
 The iGPU draws GPU memory from the GTT pool. By default the kernel exposes

--- a/modules/amd-npu.nix
+++ b/modules/amd-npu.nix
@@ -7,6 +7,12 @@
   inherit (lib) mkEnableOption mkOption mkIf types optionalString optional optionals optionalAttrs makeBinPath versionAtLeast concatStringsSep;
   cfg = config.hardware.amd-npu;
 
+  # The Tauri desktop app is the only part of lemonade that pulls a Rust/npm
+  # build (and a crates.io cargo-vendor fetch). Headless/server hosts can drop
+  # it via withDesktopApp = false so `enableLemonade` doesn't drag in that
+  # build path. See noamsto/nix-amd-ai#28.
+  lemonadePackage = pkgs.lemonade.override {withDesktopApp = cfg.lemonade.desktopApp.enable;};
+
   # 4096-byte pages: pages = GiB * 1024^3 / 4096 = GiB * 262144.
   gttPages = gib: gib * 262144;
 
@@ -148,6 +154,18 @@ in {
         description = "User account to run the Lemonade server as.";
       };
 
+      desktopApp.enable = mkOption {
+        type = types.bool;
+        default = true;
+        description = ''
+          Whether to build and install the Lemonade desktop app (the Tauri
+          shell around the web UI). This is the only part of lemonade that
+          requires a Rust + npm build and a crates.io cargo-vendor fetch.
+          Set false on headless/server hosts to skip that build path entirely
+          and ship only the `lemond` server + CLI.
+        '';
+      };
+
       flashAttn = mkOption {
         type = types.enum ["auto" "on" "off"];
         default = "on";
@@ -287,7 +305,7 @@ in {
       ]
       ++ optional cfg.enableNPU xrt-combined
       ++ optional cfg.enableFastFlowLM pkgs.fastflowlm
-      ++ optional cfg.enableLemonade pkgs.lemonade
+      ++ optional cfg.enableLemonade lemonadePackage
       ++ optional cfg.enableROCm pkgs.rocmPackages.clr
       ++ optional cfg.enableROCm pkgs.llama-cpp-rocm
       ++ optional (cfg.enableROCm && cfg.enableImageGen) pkgs.stable-diffusion-cpp-rocm
@@ -335,7 +353,7 @@ in {
       serviceConfig = {
         Type = "simple";
         User = cfg.lemonade.user;
-        ExecStart = "${pkgs.lemonade}/bin/lemond --port ${toString cfg.lemonade.port} --host ${cfg.lemonade.host}";
+        ExecStart = "${lemonadePackage}/bin/lemond --port ${toString cfg.lemonade.port} --host ${cfg.lemonade.host}";
         Restart = "on-failure";
         RestartSec = "5s";
         KillSignal = "SIGINT";


### PR DESCRIPTION
## What

Adds `hardware.amd-npu.lemonade.desktopApp.enable` (default `true`). When set `false`, lemonade is built with `withDesktopApp = false`, dropping the Tauri desktop app from the closure. The option is routed through a single `pkgs.lemonade.override` so both the `systemPackages` entry and the `lemond` `ExecStart` resolve to the same derivation.

## Why

The Tauri app is the only part of lemonade that triggers a Rust + npm build and a crates.io cargo-vendor fetch. A headless/server host enabling just `enableLemonade` was forced down that build path with no opt-out. nixpkgs' `fetch-cargo-vendor-util` downloads crate tarballs with no per-tarball retry, so a single `Connection reset by peer` fails the whole build — exactly the failure reported in #28.

The binary cache (`nix-amd-ai.cachix.org`) already side-steps this for cache users; this gives server hosts a way to drop the build path entirely.

## Test

- `nix eval` of a NixOS config with `lemonade.desktopApp.enable = false` produces a distinct lemonade derivation; `lemond` `ExecStart` points at it.
- Default (`true`) is unchanged behaviour.

Closes #28