### PR TITLE
feat(darwin): support aarch64-darwin with Metal Lemonade server

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,6 +24,20 @@ jobs:
       - name: Check flake
         run: nix flake check
 
+  build-darwin:
+    runs-on: macos-15
+    steps:
+      - uses: actions/checkout@v6
+      - uses: DeterminateSystems/nix-installer-action@main
+      - uses: cachix/cachix-action@v17
+        with:
+          name: nix-amd-ai
+          authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
+      - name: Build Lemonade (Metal)
+        run: nix build .#lemonade .#benchmark
+      - name: Check flake
+        run: nix flake check
+
   release:
     needs: build
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
@@ -65,7 +79,7 @@ jobs:
             notes="First tagged release."
           fi
 
-          lem=$(grep 'version = ' pkgs/lemonade/default.nix | head -1 | sed 's/.*"\(.*\)".*/\1/')
+          lem=$(sed -n 's/.*"\(.*\)".*/\1/p' pkgs/lemonade/version.nix | head -1)
           if [ -n "$lem" ]; then
             title="$tag — Lemonade $lem"
           else

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 AMD AI inference stack for NixOS — packages XRT, XDNA driver plugin, FastFlowLM, and Lemonade with a NixOS module for NPU + ROCm GPU support.
 
+On Apple Silicon (`aarch64-darwin`) the same flake also serves the cross-platform Lemonade server (llama.cpp Metal backend) via a nix-darwin module — see [macOS (nix-darwin)](#macos-nix-darwin). The AMD/NPU/ROCm stack is Linux-only.
+
 ## Packages
 
 | Package | Description | Source |
@@ -60,6 +62,28 @@ inputs.nix-amd-ai.url = "github:noamsto/nix-amd-ai";
   users.users.youruser.extraGroups = ["video" "render"];
 }
 ```
+
+### macOS (nix-darwin)
+
+On Apple Silicon the flake ships a `darwinModules.default` exposing `services.lemonade`. It installs the Lemonade server and runs it as a per-user LaunchAgent (the llama.cpp Metal backend needs a GUI login session, so it cannot run as a root daemon). The Metal/sd.cpp backends are fetched into `~/.cache/lemonade` on first run, exactly as the upstream `.pkg` does — there is no NPU/ROCm wiring on macOS.
+
+```nix
+# flake.nix
+inputs.nix-amd-ai.url = "github:noamsto/nix-amd-ai";
+
+# darwin configuration
+{inputs, ...}: {
+  imports = [inputs.nix-amd-ai.darwinModules.default];
+
+  services.lemonade = {
+    enable = true;
+    port = 13305;          # default
+    host = "localhost";    # default
+  };
+}
+```
+
+The package alone (no service) is also available: `nix build github:noamsto/nix-amd-ai#lemonade` on `aarch64-darwin` produces `bin/lemond` + `bin/lemonade` serving the OpenAI-compatible API at `http://localhost:13305/api/v1`. It wraps upstream's prebuilt, server-only `lemonade-embeddable-*-macos-arm64` release (no web UI / Tauri app — those ship only in the `.pkg`).
 
 ## Binary cache
 

--- a/flake.lock
+++ b/flake.lock
@@ -18,6 +18,26 @@
         "type": "github"
       }
     },
+    "nix-darwin": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1781242433,
+        "narHash": "sha256-bchLZZ3sRn740zyvD2icZSnNoTaanN0nw7l6fjVXO+E=",
+        "owner": "nix-darwin",
+        "repo": "nix-darwin",
+        "rev": "aabb2037edfc0f210723b72cd5f528aab5dd3f0b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-darwin",
+        "repo": "nix-darwin",
+        "type": "github"
+      }
+    },
     "nixpkgs": {
       "locked": {
         "lastModified": 1780749050,
@@ -52,6 +72,7 @@
     "root": {
       "inputs": {
         "flake-parts": "flake-parts",
+        "nix-darwin": "nix-darwin",
         "nixpkgs": "nixpkgs"
       }
     }

--- a/flake.nix
+++ b/flake.nix
@@ -4,6 +4,10 @@
   inputs = {
     nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
     flake-parts.url = "github:hercules-ci/flake-parts";
+    nix-darwin = {
+      url = "github:nix-darwin/nix-darwin";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
   };
 
   outputs = inputs @ {flake-parts, ...}: let
@@ -27,48 +31,65 @@
         # nixpkgs pc-fix substitute leaves a `${exec_prefix}//nix/store/.../lib`
         # artifact that the pkg-config-broken-path check rejects. Rewrite to
         # absolute paths.
-        postInstall = (old.postInstall or "") + ''
-          for pc in "$out"/lib/pkgconfig/*.pc "$dev"/lib/pkgconfig/*.pc; do
-            [ -f "$pc" ] || continue
-            sed -i \
-              -e "s|^libdir=.*$|libdir=$out/lib|" \
-              -e "s|^includedir=.*$|includedir=$dev/include|" \
-              "$pc"
-          done
-        '';
+        postInstall =
+          (old.postInstall or "")
+          + ''
+            for pc in "$out"/lib/pkgconfig/*.pc "$dev"/lib/pkgconfig/*.pc; do
+              [ -f "$pc" ] || continue
+              sed -i \
+                -e "s|^libdir=.*$|libdir=$out/lib|" \
+                -e "s|^includedir=.*$|includedir=$dev/include|" \
+                "$pc"
+            done
+          '';
       });
   in
     flake-parts.lib.mkFlake {inherit inputs;} {
-      systems = ["x86_64-linux"];
+      systems = ["x86_64-linux" "aarch64-darwin"];
 
       flake = {
         overlays.default = final: prev: let
           # Build everything against our own nixpkgs input rather than the
           # consumer's `final`, so the input closure matches CI's and Cachix
           # substitution works regardless of which channel the consumer is on.
-          pinned = import inputs.nixpkgs {inherit (final.stdenv.hostPlatform) system;};
-          libwebsockets = libwebsocketsOverride pinned;
-          xrt = pinned.callPackage ./pkgs/xrt {};
-          fastflowlm = pinned.callPackage ./pkgs/fastflowlm {inherit xrt;};
-          llama-cpp = pinned.llama-cpp;
-          llama-cpp-vulkan = pinned.llama-cpp.override {vulkanSupport = true;};
-          llama-cpp-rocm = pinned.llama-cpp-rocm;
-          whisper-cpp-vulkan = pinned.whisper-cpp.override {vulkanSupport = true;};
-          stable-diffusion-cpp-rocm = pinned.stable-diffusion-cpp.override {rocmSupport = true;};
-        in {
-          inherit xrt fastflowlm llama-cpp llama-cpp-vulkan llama-cpp-rocm libwebsockets;
-          inherit whisper-cpp-vulkan stable-diffusion-cpp-rocm;
-          xrt-plugin-amdxdna = pinned.callPackage ./pkgs/xrt-plugin-amdxdna {inherit xrt;};
-          lemonade = pinned.callPackage ./pkgs/lemonade {
-            inherit fastflowlm llama-cpp-vulkan llama-cpp-rocm libwebsockets;
+          pinned = import inputs.nixpkgs {inherit (prev.stdenv.hostPlatform) system;};
+        in
+          # Branch on `prev` (not `final`): making the overlay's key set depend
+          # on `final.stdenv` would force the fixpoint and recurse infinitely.
+          if !prev.stdenv.hostPlatform.isLinux
+          then {
+            # macOS: only the cross-platform Lemonade server (Metal backend).
+            # The AMD/XRT/ROCm stack below is Linux + AMD-hardware only.
+            lemonade = pinned.callPackage ./pkgs/lemonade/darwin.nix {};
+          }
+          else let
+            libwebsockets = libwebsocketsOverride pinned;
+            xrt = pinned.callPackage ./pkgs/xrt {};
+            fastflowlm = pinned.callPackage ./pkgs/fastflowlm {inherit xrt;};
+            llama-cpp = pinned.llama-cpp;
+            llama-cpp-vulkan = pinned.llama-cpp.override {vulkanSupport = true;};
+            llama-cpp-rocm = pinned.llama-cpp-rocm;
+            whisper-cpp-vulkan = pinned.whisper-cpp.override {vulkanSupport = true;};
+            stable-diffusion-cpp-rocm = pinned.stable-diffusion-cpp.override {rocmSupport = true;};
+          in {
+            inherit xrt fastflowlm llama-cpp llama-cpp-vulkan llama-cpp-rocm libwebsockets;
             inherit whisper-cpp-vulkan stable-diffusion-cpp-rocm;
-            inherit (pinned) whisper-cpp stable-diffusion-cpp;
+            xrt-plugin-amdxdna = pinned.callPackage ./pkgs/xrt-plugin-amdxdna {inherit xrt;};
+            lemonade = pinned.callPackage ./pkgs/lemonade {
+              inherit fastflowlm llama-cpp-vulkan llama-cpp-rocm libwebsockets;
+              inherit whisper-cpp-vulkan stable-diffusion-cpp-rocm;
+              inherit (pinned) whisper-cpp stable-diffusion-cpp;
+            };
+            gaia = pinned.callPackage ./pkgs/gaia {};
           };
-          gaia = pinned.callPackage ./pkgs/gaia {};
-        };
 
         nixosModules.default = {
           imports = [./modules/amd-npu.nix];
+          nixpkgs.overlays = [inputs.self.overlays.default];
+        };
+
+        darwinModules.default = {
+          imports = [./modules/lemonade-darwin.nix];
           nixpkgs.overlays = [inputs.self.overlays.default];
         };
       };
@@ -78,16 +99,19 @@
         system,
         ...
       }: let
-        xrt = pkgs.callPackage ./pkgs/xrt {};
-        fastflowlm = pkgs.callPackage ./pkgs/fastflowlm {inherit xrt;};
-        llama-cpp = pkgs.llama-cpp;
-        llama-cpp-vulkan = pkgs.llama-cpp.override {vulkanSupport = true;};
-        llama-cpp-rocm = pkgs.llama-cpp-rocm;
-        whisper-cpp-vulkan = pkgs.whisper-cpp.override {vulkanSupport = true;};
-        stable-diffusion-cpp-rocm = pkgs.stable-diffusion-cpp.override {rocmSupport = true;};
-        libwebsockets = libwebsocketsOverride pkgs;
-      in {
-        packages = {
+        isLinux = inputs.nixpkgs.lib.hasSuffix "linux" system;
+
+        # AMD NPU/XRT/ROCm/Vulkan stack — Linux + AMD-hardware only.
+        linuxPackages = let
+          xrt = pkgs.callPackage ./pkgs/xrt {};
+          fastflowlm = pkgs.callPackage ./pkgs/fastflowlm {inherit xrt;};
+          llama-cpp = pkgs.llama-cpp;
+          llama-cpp-vulkan = pkgs.llama-cpp.override {vulkanSupport = true;};
+          llama-cpp-rocm = pkgs.llama-cpp-rocm;
+          whisper-cpp-vulkan = pkgs.whisper-cpp.override {vulkanSupport = true;};
+          stable-diffusion-cpp-rocm = pkgs.stable-diffusion-cpp.override {rocmSupport = true;};
+          libwebsockets = libwebsocketsOverride pkgs;
+        in {
           inherit xrt fastflowlm llama-cpp llama-cpp-vulkan llama-cpp-rocm libwebsockets;
           inherit whisper-cpp-vulkan stable-diffusion-cpp-rocm;
           xrt-plugin-amdxdna = pkgs.callPackage ./pkgs/xrt-plugin-amdxdna {inherit xrt;};
@@ -98,116 +122,183 @@
             stable-diffusion-cpp = pkgs.stable-diffusion-cpp;
           };
           gaia = pkgs.callPackage ./pkgs/gaia {};
-          benchmark = pkgs.callPackage ./pkgs/benchmark-go {};
         };
 
-        checks = {
-          module-eval-rocm-false = (inputs.nixpkgs.lib.nixosSystem {
-            inherit system;
-            modules = [
-              inputs.self.nixosModules.default
-              {
-                boot.loader.grub.enable = false;
-                fileSystems."/" = { device = "/dev/sda1"; fsType = "ext4"; };
-                hardware.amd-npu = {
-                  enable = true;
-                  enableFastFlowLM = true;
-                  enableLemonade = true;
-                  enableROCm = false;
-                  lemonade.user = "testuser";
-                };
-                users.users.testuser = {
-                  isNormalUser = true;
-                  extraGroups = ["video" "render"];
-                };
-              }
-            ];
-          }).config.system.build.etc;
-
-          module-eval-rocm-true = (inputs.nixpkgs.lib.nixosSystem {
-            inherit system;
-            modules = [
-              inputs.self.nixosModules.default
-              {
-                boot.loader.grub.enable = false;
-                fileSystems."/" = { device = "/dev/sda1"; fsType = "ext4"; };
-                hardware.amd-npu = {
-                  enable = true;
-                  enableFastFlowLM = true;
-                  enableLemonade = true;
-                  enableROCm = true;
-                  lemonade.user = "testuser";
-                };
-                users.users.testuser = {
-                  isNormalUser = true;
-                  extraGroups = ["video" "render"];
-                };
-              }
-            ];
-          }).config.system.build.etc;
-
-          module-eval-vulkan-true = (inputs.nixpkgs.lib.nixosSystem {
-            inherit system;
-            modules = [
-              inputs.self.nixosModules.default
-              {
-                boot.loader.grub.enable = false;
-                fileSystems."/" = { device = "/dev/sda1"; fsType = "ext4"; };
-                hardware.amd-npu = {
-                  enable = true;
-                  enableFastFlowLM = true;
-                  enableLemonade = true;
-                  enableROCm = false;
-                  enableVulkan = true;
-                  lemonade.user = "noams";
-                };
-                users.users.noams = {
-                  isNormalUser = true;
-                  extraGroups = ["video" "render"];
-                };
-              }
-            ];
-          }).config.system.build.etc;
-
-          # GTT headroom: configured system emits the ttm modprobe line with
-          # GiB→page conversion; default system emits no ttm line.
-          module-eval-gtt = let
-            mkSys = extra: (inputs.nixpkgs.lib.nixosSystem {
-              inherit system;
-              modules = [
-                inputs.self.nixosModules.default
-                {
-                  boot.loader.grub.enable = false;
-                  fileSystems."/" = { device = "/dev/sda1"; fsType = "ext4"; };
-                  hardware.amd-npu = {
-                    enable = true;
-                    lemonade.user = "testuser";
-                  } // extra;
-                  users.users.testuser = {
-                    isNormalUser = true;
-                    extraGroups = ["video" "render"];
-                  };
-                }
-              ];
-            }).config.boot.extraModprobeConfig;
-            configured = mkSys {
-              gpuMemory = { ttmSizeGiB = 120; pagePoolSizeGiB = 60; };
-            };
-            ttmOnly = mkSys {
-              gpuMemory = { ttmSizeGiB = 10; };
-            };
-            default = mkSys {};
-          in
-            pkgs.runCommand "module-eval-gtt" {
-              inherit configured ttmOnly default;
-            } ''
-              echo "$configured" | grep -F 'options ttm pages_limit=31457280 page_pool_size=15728640'
-              echo "$ttmOnly" | grep -F 'options ttm pages_limit=2621440'
-              echo "$ttmOnly" | grep -vq 'page_pool_size' || { echo "ttm-only must not set page_pool_size"; exit 1; }
-              echo "$default" | grep -vq 'pages_limit' || { echo "default must not set pages_limit"; exit 1; }
-              touch $out
-            '';
+        # macOS: server-only Lemonade wrap (Metal backend, fetched at runtime).
+        darwinPackages = {
+          lemonade = pkgs.callPackage ./pkgs/lemonade/darwin.nix {};
         };
+      in {
+        packages =
+          (
+            if isLinux
+            then linuxPackages
+            else darwinPackages
+          )
+          // {
+            # Pure Go — builds on every system.
+            benchmark = pkgs.callPackage ./pkgs/benchmark-go {};
+          };
+
+        # Module eval checks: NixOS module on Linux, nix-darwin module on macOS.
+        checks =
+          if isLinux
+          then {
+            module-eval-rocm-false =
+              (inputs.nixpkgs.lib.nixosSystem {
+                inherit system;
+                modules = [
+                  inputs.self.nixosModules.default
+                  {
+                    boot.loader.grub.enable = false;
+                    fileSystems."/" = {
+                      device = "/dev/sda1";
+                      fsType = "ext4";
+                    };
+                    hardware.amd-npu = {
+                      enable = true;
+                      enableFastFlowLM = true;
+                      enableLemonade = true;
+                      enableROCm = false;
+                      lemonade.user = "testuser";
+                    };
+                    users.users.testuser = {
+                      isNormalUser = true;
+                      extraGroups = ["video" "render"];
+                    };
+                  }
+                ];
+              }).config.system.build.etc;
+
+            module-eval-rocm-true =
+              (inputs.nixpkgs.lib.nixosSystem {
+                inherit system;
+                modules = [
+                  inputs.self.nixosModules.default
+                  {
+                    boot.loader.grub.enable = false;
+                    fileSystems."/" = {
+                      device = "/dev/sda1";
+                      fsType = "ext4";
+                    };
+                    hardware.amd-npu = {
+                      enable = true;
+                      enableFastFlowLM = true;
+                      enableLemonade = true;
+                      enableROCm = true;
+                      lemonade.user = "testuser";
+                    };
+                    users.users.testuser = {
+                      isNormalUser = true;
+                      extraGroups = ["video" "render"];
+                    };
+                  }
+                ];
+              }).config.system.build.etc;
+
+            module-eval-vulkan-true =
+              (inputs.nixpkgs.lib.nixosSystem {
+                inherit system;
+                modules = [
+                  inputs.self.nixosModules.default
+                  {
+                    boot.loader.grub.enable = false;
+                    fileSystems."/" = {
+                      device = "/dev/sda1";
+                      fsType = "ext4";
+                    };
+                    hardware.amd-npu = {
+                      enable = true;
+                      enableFastFlowLM = true;
+                      enableLemonade = true;
+                      enableROCm = false;
+                      enableVulkan = true;
+                      lemonade.user = "noams";
+                    };
+                    users.users.noams = {
+                      isNormalUser = true;
+                      extraGroups = ["video" "render"];
+                    };
+                  }
+                ];
+              }).config.system.build.etc;
+
+            # GTT headroom: configured system emits the ttm modprobe line with
+            # GiB→page conversion; default system emits no ttm line.
+            module-eval-gtt = let
+              mkSys = extra:
+                (inputs.nixpkgs.lib.nixosSystem {
+                  inherit system;
+                  modules = [
+                    inputs.self.nixosModules.default
+                    {
+                      boot.loader.grub.enable = false;
+                      fileSystems."/" = {
+                        device = "/dev/sda1";
+                        fsType = "ext4";
+                      };
+                      hardware.amd-npu =
+                        {
+                          enable = true;
+                          lemonade.user = "testuser";
+                        }
+                        // extra;
+                      users.users.testuser = {
+                        isNormalUser = true;
+                        extraGroups = ["video" "render"];
+                      };
+                    }
+                  ];
+                }).config.boot.extraModprobeConfig;
+              configured = mkSys {
+                gpuMemory = {
+                  ttmSizeGiB = 120;
+                  pagePoolSizeGiB = 60;
+                };
+              };
+              ttmOnly = mkSys {
+                gpuMemory = {ttmSizeGiB = 10;};
+              };
+              default = mkSys {};
+            in
+              pkgs.runCommand "module-eval-gtt" {
+                inherit configured ttmOnly default;
+              } ''
+                echo "$configured" | grep -F 'options ttm pages_limit=31457280 page_pool_size=15728640'
+                echo "$ttmOnly" | grep -F 'options ttm pages_limit=2621440'
+                echo "$ttmOnly" | grep -vq 'page_pool_size' || { echo "ttm-only must not set page_pool_size"; exit 1; }
+                echo "$default" | grep -vq 'pages_limit' || { echo "default must not set pages_limit"; exit 1; }
+                touch $out
+              '';
+          }
+          else {
+            # Force the nix-darwin module to evaluate and assert the launchd
+            # agent wires lemond with the configured port.
+            module-eval-darwin = let
+              cfg =
+                (inputs.nix-darwin.lib.darwinSystem {
+                  inherit system;
+                  modules = [
+                    inputs.self.darwinModules.default
+                    {
+                      services.lemonade = {
+                        enable = true;
+                        port = 13305;
+                      };
+                      system.stateVersion = 6;
+                      system.primaryUser = "testuser";
+                      users.users.testuser.home = "/Users/testuser";
+                    }
+                  ];
+                }).config;
+              cmdline = builtins.concatStringsSep " " cfg.launchd.user.agents.lemonade.serviceConfig.ProgramArguments;
+            in
+              pkgs.runCommand "module-eval-darwin" {inherit cmdline;} ''
+                echo "$cmdline" | grep -F -- '--port 13305'
+                echo "$cmdline" | grep -F 'bin/lemond'
+                touch $out
+              '';
+          };
 
         apps.benchmark = {
           type = "app";

--- a/modules/lemonade-darwin.nix
+++ b/modules/lemonade-darwin.nix
@@ -1,0 +1,54 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}: let
+  inherit (lib) mkEnableOption mkPackageOption mkOption mkIf types getExe;
+  cfg = config.services.lemonade;
+in {
+  options.services.lemonade = {
+    enable = mkEnableOption "the Lemonade AI server (macOS, llama.cpp Metal backend)";
+
+    package = mkPackageOption pkgs "lemonade" {};
+
+    host = mkOption {
+      type = types.str;
+      default = "localhost";
+      description = "Address for the Lemonade server to bind to.";
+    };
+
+    port = mkOption {
+      type = types.port;
+      default = 13305;
+      description = "Port for the Lemonade server.";
+    };
+  };
+
+  config = mkIf cfg.enable {
+    environment.systemPackages = [cfg.package];
+
+    # user.agents (not agents): nix-darwin activates these via
+    # `launchctl asuser <uid> … load`, so the agent starts in the primary
+    # user's GUI session on `darwin-rebuild switch` and runs as that user —
+    # required because lemond's llama.cpp Metal backend reaches the GPU
+    # through the user session, not a root daemon. lemond fetches the Metal
+    # backend into ~/.cache/lemonade on first run, like the upstream .pkg.
+    launchd.user.agents.lemonade = {
+      serviceConfig = {
+        ProgramArguments = [
+          (getExe cfg.package)
+          "--port"
+          (toString cfg.port)
+          "--host"
+          cfg.host
+        ];
+        RunAtLoad = true;
+        # Respawn on crash, but not after a clean `launchctl stop` / exit.
+        KeepAlive = {Crashed = true;};
+        StandardOutPath = "/Users/${config.system.primaryUser}/Library/Logs/lemonade.log";
+        StandardErrorPath = "/Users/${config.system.primaryUser}/Library/Logs/lemonade.log";
+      };
+    };
+  };
+}

--- a/pkgs/lemonade/darwin.nix
+++ b/pkgs/lemonade/darwin.nix
@@ -1,0 +1,48 @@
+{
+  lib,
+  stdenvNoCC,
+  fetchurl,
+}: let
+  version = import ./version.nix;
+in
+  stdenvNoCC.mkDerivation {
+    pname = "lemonade";
+    inherit version;
+
+    # Upstream ships a relocatable, server-only bundle for Apple Silicon:
+    # lemond + lemonade CLI + resources/, no web UI / Tauri app (those are
+    # .pkg-only). The Metal llama.cpp / sd.cpp backends are fetched into the
+    # user cache at first run, exactly as the official .pkg does.
+    src = fetchurl {
+      url = "https://github.com/lemonade-sdk/lemonade/releases/download/v${version}/lemonade-embeddable-${version}-macos-arm64.tar.gz";
+      hash = "sha256-Zz+6FoQsHu3TOMq3b+CfFnaa9kO9fwYo0sKCmc74O/M=";
+    };
+
+    # The Mach-O binaries are adhoc-signed and link only against system
+    # libraries and frameworks (incl. Metal) — no @rpath, no bundled dylibs.
+    # Any install-name/rpath rewrite would break the signature, so skip fixup
+    # entirely and place the files verbatim.
+    dontConfigure = true;
+    dontBuild = true;
+    dontFixup = true;
+
+    # lemond resolves its resources/ relative to the invoked binary, so keep
+    # resources adjacent to lemond in $out/bin (mirrors the Linux build's
+    # bin/resources symlink).
+    installPhase = ''
+      runHook preInstall
+      mkdir -p $out/bin
+      cp -r lemond lemonade resources $out/bin/
+      install -Dm644 LICENSE $out/share/doc/lemonade/LICENSE
+      runHook postInstall
+    '';
+
+    meta = {
+      description = "Local AI server with OpenAI-compatible API (Metal backend, macOS)";
+      homepage = "https://github.com/lemonade-sdk/lemonade";
+      license = lib.licenses.asl20;
+      platforms = ["aarch64-darwin"];
+      sourceProvenance = [lib.sourceTypes.binaryNativeCode];
+      mainProgram = "lemond";
+    };
+  }

--- a/pkgs/lemonade/default.nix
+++ b/pkgs/lemonade/default.nix
@@ -32,7 +32,7 @@
   withWebApp ? true,
   withDesktopApp ? true,
 }: let
-  version = "10.7.0";
+  version = import ./version.nix;
 
   src = fetchFromGitHub {
     owner = "lemonade-sdk";

--- a/pkgs/lemonade/version.nix
+++ b/pkgs/lemonade/version.nix
@@ -1,0 +1,5 @@
+# Single source of truth for the Lemonade version, shared by the Linux source
+# build (default.nix) and the macOS prebuilt wrap (darwin.nix). The update
+# workflow (scripts/bump-versions.sh) bumps this file and refreshes both the
+# source-tarball hash (default.nix) and the embeddable-bundle hash (darwin.nix).
+"10.7.0"

--- a/scripts/bump-versions.sh
+++ b/scripts/bump-versions.sh
@@ -28,12 +28,28 @@ if [ "$FLM_NEW" != "$FLM_OLD" ]; then
   update_hash fastflowlm
 fi
 
-# Lemonade
+# Lemonade — one version (pkgs/lemonade/version.nix) feeds both the Linux source
+# build and the macOS prebuilt wrap, but they fetch different tarballs and so
+# carry separate hashes.
 if [ "$LEM_NEW" != "$LEM_OLD" ]; then
   echo "Bumping Lemonade: $LEM_OLD -> $LEM_NEW"
-  sed -i "s/version = \"$LEM_OLD\"/version = \"$LEM_NEW\"/" pkgs/lemonade/default.nix
+  sed -i "s/\"$LEM_OLD\"/\"$LEM_NEW\"/" pkgs/lemonade/version.nix
+
+  # Linux source tarball: blank + rebuild to capture the new hash.
   sed -i 's/hash = "sha256-[^"]*"/hash = ""/' pkgs/lemonade/default.nix
   update_hash lemonade
+
+  # macOS embeddable bundle: a fixed-output fetch, so prefetch the URL directly
+  # (works on the Linux CI runner, where the aarch64-darwin package can't build).
+  echo "  Prefetching macOS embeddable hash..."
+  darwin_url="https://github.com/lemonade-sdk/lemonade/releases/download/v${LEM_NEW}/lemonade-embeddable-${LEM_NEW}-macos-arm64.tar.gz"
+  darwin_hash=$(nix store prefetch-file --json "$darwin_url" | jq -r .hash || true)
+  if [ -n "$darwin_hash" ]; then
+    sed -i "s|hash = \"sha256-[^\"]*\"|hash = \"$darwin_hash\"|" pkgs/lemonade/darwin.nix
+    echo "  macOS hash updated: $darwin_hash"
+  else
+    echo "  WARNING: could not prefetch macOS embeddable hash for $LEM_NEW"
+  fi
 fi
 
 # xdna-driver (also check XRT submodule)

--- a/scripts/check-updates.sh
+++ b/scripts/check-updates.sh
@@ -8,7 +8,7 @@ LEM_LATEST=$(gh api repos/lemonade-sdk/lemonade/releases/latest --jq '.tag_name'
 XDNA_LATEST=$(gh api "repos/amd/xdna-driver/commits?sha=1.7&per_page=1" --jq '.[0].sha')
 
 FLM_CURRENT=$(grep 'version = ' pkgs/fastflowlm/default.nix | head -1 | sed 's/.*"\(.*\)".*/\1/')
-LEM_CURRENT=$(grep 'version = ' pkgs/lemonade/default.nix | head -1 | sed 's/.*"\(.*\)".*/\1/')
+LEM_CURRENT=$(sed -n 's/.*"\(.*\)".*/\1/p' pkgs/lemonade/version.nix | head -1)
 XDNA_CURRENT=$(grep 'rev = ' pkgs/xrt-plugin-amdxdna/default.nix | head -1 | sed 's/.*"\(.*\)".*/\1/')
 
 NEEDS_UPDATE=false


### PR DESCRIPTION
Closes #31.

Adds `aarch64-darwin` to the flake and exposes the cross-platform Lemonade server on Apple Silicon (llama.cpp Metal backend), while keeping the AMD/XRT/ROCm/NPU stack Linux-only.

## Approach
Rather than source-building a Metal branch (the expensive option #31 anticipated), this wraps upstream's prebuilt, server-only `lemonade-embeddable-*-macos-arm64` release. Its Mach-O binaries are adhoc-signed and link only against system libs/frameworks (incl. `Metal.framework`) with **no `@rpath`** — so Nix never rewrites install-names and the signature stays valid (`dontFixup`). Backends self-fetch into `~/.cache/lemonade` on first run, exactly as the official `.pkg` does.

## Changes
- **`pkgs/lemonade/darwin.nix`** — wraps the embeddable bundle (server-only: no web UI / Tauri app, which ship only in the `.pkg`).
- **`flake.nix`** — `aarch64-darwin` added to `systems`; overlay + `perSystem` branch on platform (via `prev.stdenv` to avoid overlay fixpoint recursion); darwin exposes only `lemonade` + `benchmark`.
- **`darwinModules.default`** — `services.lemonade`, running `lemond` as a per-user LaunchAgent (`launchd.user.agents`, loaded via `launchctl asuser` so it starts in the user's GUI session for Metal access).
- **`pkgs/lemonade/version.nix`** — single source of truth for the version shared by the Linux source build and the macOS wrap (separate tarball hashes); `bump-versions.sh` now refreshes both (macOS via `nix store prefetch-file`, runnable on the Linux CI runner).
- **checks** — NixOS module eval on Linux, nix-darwin module eval on darwin.
- **CI** — adds a `macos-15` build job. README documents the darwin path.

## Verified on aarch64-darwin
- `nix build .#lemonade` builds; `lemond`/`lemonade` run, adhoc signature intact after Nix copy.
- Server answers `GET /api/v1/models` and resolves `resources/` from the store path.
- `nix flake check` green on `aarch64-darwin` (incl. nix-darwin module eval check).
- Linux outputs unchanged (12 packages, 4 checks still evaluate).
- `nix store prefetch-file` reproduces the exact darwin hash pin; `shellcheck` clean.

## Known limitations / not covered
- **End-to-end Metal inference not tested** — verified the server boots, serves the API, resolves resources, and links `Metal.framework`, but no model was loaded / token generated (needs network + multi-GB backend download).
- **`darwin-rebuild switch` not exercised** — the `launchd.user.agents` behavior is validated by plist eval and reading nix-darwin's activation source, not a live switch.
- **No `global_timeout` override on darwin** — Linux sets it to `0`; macOS uses upstream's 600s, so long generations can time out. Follow-up.
- **`benchmark` on macOS is a hollow build** — its ROCm/Vulkan/FLM backends do not exist on Apple Silicon (no Metal mode yet).
- **Intel Macs (`x86_64-darwin`)** — out of scope; the embeddable bundle is arm64-only.