### PR TITLE
ci: add Dependabot for GitHub Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
Adds weekly Dependabot updates for GitHub Actions pins only. The existing update.yml already tracks upstream package releases and flake.lock (nixpkgs) — that does more than Dependabot's nix ecosystem can, so it is kept and Dependabot nix is intentionally NOT added to avoid duplicate flake.lock PRs.