### PR TITLE
ci(update): auto-merge clean dependency bumps

### DIFF
--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -77,6 +77,7 @@ jobs:
           } >> "$GITHUB_OUTPUT"
 
       - name: Create PR
+        id: pr
         if: steps.check.outputs.needs_update == 'true'
         env:
           GH_TOKEN: ${{ github.token }}
@@ -128,4 +129,19 @@ jobs:
 
           BODY+=$'\n'"**Note:** Hashes may need manual correction if auto-prefetch failed."
 
-          echo "$BODY" | gh pr create --title "chore: bump upstream package versions" --body-file -
+          PR_URL=$(echo "$BODY" | gh pr create --title "chore: bump upstream package versions" --body-file -)
+          echo "pr_url=$PR_URL" >> "$GITHUB_OUTPUT"
+
+      # Auto-merge only the clean path: this job already built the 4 packages and
+      # ran flake check on the bumped tree, so build success here IS the gate.
+      # MTP hand-bumps still build green with a stale override, so they stay for
+      # review. The push to main then triggers build.yml's release job.
+      - name: Auto-merge clean bumps
+        if: |
+          steps.pr.outputs.pr_url != '' &&
+          steps.flake_check.outputs.status == 'pass' &&
+          steps.build.outputs.failed == '' &&
+          steps.check.outputs.mtp_override_needs_update != 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: gh pr merge --squash --delete-branch "${{ steps.pr.outputs.pr_url }}"


### PR DESCRIPTION
## What

Adds an **Auto-merge clean bumps** step to the weekly `update.yml` job. The job already builds the 4 packages and runs `nix flake check` on the bumped tree; this gates an immediate squash-merge (+ branch delete) on that in-job success, so clean bumps ship without a manual click. The resulting push to `main` triggers the existing `release` job in `build.yml` — no change needed there.

## Guards (all four must hold to merge)

| Guard | Catches |
|---|---|
| `build.outputs.failed == ''` | the build check — stale/wrong FOD hashes fail the build |
| `flake_check.outputs.status == 'pass'` | eval breakage |
| `mtp_override_needs_update != 'true'` | the one case a green build *can't* catch (stale llama.cpp override) |
| `pr.outputs.pr_url != ''` | no diff / `gh pr create` failure |

Anything else (MTP hand-bumps, build/flake-check failures) still opens a PR and waits for review, with failure annotations intact.

## Notes

- Uses immediate `gh pr merge --squash` rather than `--auto`: the job already validated this exact tree, and `--auto` would require "Allow auto-merge" in repo settings. If branch protection with required checks is later added to `main`, switch to `--auto --squash`.
- Verifiable only on a real cron/`workflow_dispatch` run.