### PR TITLE
fix(module): lemond runtime dir + nix-ld loader for omni backends

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,6 +23,24 @@ jobs:
         run: nix build .#xrt .#xrt-plugin-amdxdna .#fastflowlm .#lemonade
       - name: Check flake
         run: nix flake check
+      - name: Verify lemond unit (systemd-analyze)
+        run: |
+          unit=$(nix build .#lemond-unit --print-out-paths)/lemond.service
+
+          # Self-check: prove the verifier actually flags a bad unit, so a clean
+          # pass below can't mask a missing/dead systemd-analyze on the runner.
+          printf '[Unit]\nDescription=ctl\n[Service]\nExecStart=/bin/true\nRuntimeDirectory=/absolute/bad\n' > ctl.service
+          systemd-analyze verify ctl.service 2>&1 | grep -qi 'RuntimeDirectory' \
+            || { echo "systemd-analyze did not flag a known-bad unit; aborting"; exit 1; }
+
+          # A valid unit yields no diagnostic mentioning our directives, so any
+          # mention of them is a real problem. (ExecStart points at an unbuilt
+          # store path, which verify reports separately — ignored via || true.)
+          report=$(systemd-analyze verify "$unit" 2>&1 || true)
+          echo "$report"
+          if echo "$report" | grep -Ei 'RuntimeDirectory|NIX_LD'; then
+            echo "systemd-analyze flagged lemond's directives"; exit 1
+          fi
 
   build-darwin:
     runs-on: macos-15

--- a/README.md
+++ b/README.md
@@ -156,6 +156,8 @@ The lemonade source build deliberately doesn't bundle backend `llama-server` / `
 | `enableVulkan` | `llamacpp:vulkan`, `whispercpp:vulkan` |
 | `enableImageGen` (default true) | Gates all `sd-cpp:*` packages; turn off for ~150 MB CPU / ~1.5 GB ROCm savings on headless LLM-only hosts |
 
+Omni models (e.g. `LMX-Omni-*`) pull in two backends that need extra host plumbing the module wires automatically with `enableLemonade` ([#33](https://github.com/noamsto/nix-amd-ai/issues/33)): `whispercpp` resolves its writable runtime dir from the unit's `RuntimeDirectory`, and the runtime-downloaded kokoro TTS binary is a foreign prebuilt ELF, so the module enables `nix-ld` (its default libraries already cover koko's openssl + gcc-libs) and re-exports `NIX_LD*` into the `lemond` service. nix-ld is set via `mkDefault`, so hosts managing it themselves can opt out.
+
 Lemonade v10.4.0 added an experimental `llamacpp:vllm` (vLLM ROCm) backend for Strix Halo / Strix Point on Linux. We don't wire it: on Strix Point gfx1150 our benchmarks already show Vulkan ahead of ROCm for both prefill and decode, vLLM's batching wins don't apply to single-user lemonade workloads, and upstream still distributes it as a TheRock-style prebuilt blob with no env-var migration. Revisit when it leaves experimental, when a Strix Halo host lands here, or if anyone benchmarks it past Vulkan on gfx1150.
 
 Vanilla v10.5.0 ignores these env vars on NixOS for several reasons that this flake patches in-tree (see `pkgs/lemonade/default.nix:postPatch`, [issue #5](https://github.com/noamsto/nix-amd-ai/issues/5), upstream [lemonade-sdk/lemonade#1791](https://github.com/lemonade-sdk/lemonade/issues/1791)):

--- a/flake.nix
+++ b/flake.nix
@@ -122,12 +122,39 @@
             stable-diffusion-cpp = pkgs.stable-diffusion-cpp;
           };
           gaia = pkgs.callPackage ./pkgs/gaia {};
+          lemond-unit = lemondUnit;
         };
 
         # macOS: server-only Lemonade wrap (Metal backend, fetched at runtime).
         darwinPackages = {
           lemonade = pkgs.callPackage ./pkgs/lemonade/darwin.nix {};
         };
+
+        # Rendered lemond.service for a minimal enableLemonade host — consumed by
+        # the lemond-unit-render check and the CI systemd-analyze step.
+        lemondUnit =
+          (inputs.nixpkgs.lib.nixosSystem {
+            inherit system;
+            modules = [
+              inputs.self.nixosModules.default
+              {
+                boot.loader.grub.enable = false;
+                fileSystems."/" = {
+                  device = "/dev/sda1";
+                  fsType = "ext4";
+                };
+                hardware.amd-npu = {
+                  enable = true;
+                  enableLemonade = true;
+                  lemonade.user = "testuser";
+                };
+                users.users.testuser = {
+                  isNormalUser = true;
+                  extraGroups = ["video" "render"];
+                };
+              }
+            ];
+          }).config.systemd.units."lemond.service".unit;
       in {
         packages =
           (
@@ -270,6 +297,21 @@
                 echo "$default" | grep -vq 'pages_limit' || { echo "default must not set pages_limit"; exit 1; }
                 touch $out
               '';
+
+            # The lemond unit must keep its writable runtime dir + nix-ld loader
+            # env, else omni backends (WhisperServer, koko TTS) fail to load. The
+            # NIX_LD paths track the values nix-ld exports as session vars.
+            # (Semantic `systemd-analyze verify` runs in CI — it can't create
+            # /run/systemd inside nix's build sandbox.)
+            lemond-unit-render = pkgs.runCommand "lemond-unit-render" {} ''
+              unit=${lemondUnit}/lemond.service
+              grep -q 'RuntimeDirectory=lemond' "$unit" || { echo "missing RuntimeDirectory"; exit 1; }
+              grep -q 'NIX_LD=/run/current-system/sw/share/nix-ld/lib/ld.so' "$unit" \
+                || { echo "missing/changed NIX_LD"; exit 1; }
+              grep -q 'NIX_LD_LIBRARY_PATH=/run/current-system/sw/share/nix-ld/lib' "$unit" \
+                || { echo "missing/changed NIX_LD_LIBRARY_PATH"; exit 1; }
+              touch $out
+            '';
           }
           else {
             # Force the nix-darwin module to evaluate and assert the launchd

--- a/modules/amd-npu.nix
+++ b/modules/amd-npu.nix
@@ -4,7 +4,7 @@
   pkgs,
   ...
 }: let
-  inherit (lib) mkEnableOption mkOption mkIf types optionalString optional optionals optionalAttrs makeBinPath versionAtLeast concatStringsSep;
+  inherit (lib) mkEnableOption mkOption mkIf mkDefault types optionalString optional optionals optionalAttrs makeBinPath versionAtLeast concatStringsSep;
   cfg = config.hardware.amd-npu;
 
   # The Tauri desktop app is the only part of lemonade that pulls a Rust/npm
@@ -114,7 +114,11 @@ in {
     enableLemonade = mkOption {
       type = types.bool;
       default = true;
-      description = "Whether to enable the Lemonade AI server.";
+      description = ''
+        Whether to enable the Lemonade AI server. Also enables nix-ld
+        (overridable via `programs.nix-ld.enable`) so runtime-downloaded omni
+        backends — e.g. the kokoro TTS ELF — can find a dynamic loader.
+      '';
     };
 
     enableROCm = mkOption {
@@ -319,6 +323,12 @@ in {
       ]
       ++ optional (cfg.enableLemonade && cfg.enableImageGen) pkgs.stable-diffusion-cpp;
 
+    # koko (kokoro TTS) is a runtime-downloaded prebuilt ELF that asks for
+    # /lib64/ld-linux-x86-64.so.2; nix-ld swaps the stub for a real loader, and
+    # its default libraries already cover koko's needs (openssl, gcc-libs).
+    # mkDefault so hosts managing nix-ld themselves can still opt out.
+    programs.nix-ld.enable = mkIf cfg.enableLemonade (mkDefault true);
+
     # Lemonade systemd service
     systemd.services.lemond = mkIf cfg.enableLemonade {
       description = "Lemonade AI Server";
@@ -349,6 +359,12 @@ in {
           # Suppress FLM's auto-update probe in the lemond-spawned subprocess.
           # New in FLM 0.9.41.
           FLM_DISABLE_UPDATE_CHECK = "1";
+        }
+        // optionalAttrs config.programs.nix-ld.enable {
+          # nix-ld exports these only as session vars; the unit doesn't inherit
+          # them, so koko's loader can't find them without re-exporting here.
+          NIX_LD = config.environment.sessionVariables.NIX_LD;
+          NIX_LD_LIBRARY_PATH = config.environment.sessionVariables.NIX_LD_LIBRARY_PATH;
         };
       serviceConfig = {
         Type = "simple";
@@ -358,6 +374,8 @@ in {
         RestartSec = "5s";
         KillSignal = "SIGINT";
         LimitMEMLOCK = "infinity";
+        # WhisperServer resolves its writable runtime dir from RUNTIME_DIRECTORY.
+        RuntimeDirectory = "lemond";
       };
     };
   };


### PR DESCRIPTION
Fixes two of the three packaging defects reported in #33 by @cormacc on Strix Halo, when loading the LMX-Omni-52B-Halo omni collection. Both are clean, hardware-independent module changes (defect #1, the sd-server RUNPATH, is left for a follow-up).

## Defect #2 — WhisperServer has no writable runtime dir
`WhisperServer` fails with `Unable to resolve writable runtime directory from XDG_RUNTIME_DIR or RUNTIME_DIRECTORY`. The `lemond` unit set neither.

→ `serviceConfig.RuntimeDirectory = "lemond"` — systemd creates `/run/lemond` (owned by `lemonade.user`) and exports `$RUNTIME_DIRECTORY`.

## Defect #3 — koko (kokoro TTS) foreign ELF cannot run on NixOS
lemonade downloads `koko` at runtime; it requests `/lib64/ld-linux-x86-64.so.2` and hits NixOSs stub loader (`Could not start dynamically linked executable`, exit 127).

→ `programs.nix-ld.enable` (swaps the stub for a real loader) + re-export `NIX_LD` / `NIX_LD_LIBRARY_PATH` into the unit, since nix-ld only exports them as session vars and systemd units dont inherit those. Verified against the pinned nixpkgs that nix-lds default `libraries` already cover kokos needs (openssl, gcc-libs), so no extra libs are required.

### Notes
- `programs.nix-ld.enable` is gated on `enableLemonade` and set via `mkDefault`, so hosts managing nix-ld themselves can opt out without a definition conflict. When nix-ld is off, the `NIX_LD*` env lines drop from the unit; `RuntimeDirectory` stays.
- The `NIX_LD*` values track the paths nix-ld exports (`/run/current-system/sw/share/nix-ld/lib...`) rather than hardcoding them.

## Tests
- `checks.lemond-unit-render` — builds the real `lemond.service` and asserts it keeps `RuntimeDirectory` + the `NIX_LD*` env (runs in `nix flake check`).
- CI step `Verify lemond unit (systemd-analyze)` — runs `systemd-analyze verify` on the rendered unit on the runner (it cannot run in nixs build sandbox: no writable `/run/systemd`), with a negative control so a missing/dead verifier fails loud instead of passing silently.
- New `packages.lemond-unit` exposes the rendered unit for both.

Refs #33