### PR TITLE
fix(module): keep ggml engine binaries off the system PATH

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -312,6 +312,39 @@
                 || { echo "missing/changed NIX_LD_LIBRARY_PATH"; exit 1; }
               touch $out
             '';
+
+            # The /etc/lemonade/backends/* symlinks exist only to feed lemond, so
+            # they must not appear when enableLemonade is off — even with ROCm and
+            # Vulkan on. Reads environment.etc attr names only, so it skips the
+            # bootloader/root-fs stubs (and engine builds) the other checks force
+            # via system.build.etc.
+            module-eval-lemonade-false = let
+              etcNames =
+                builtins.concatStringsSep "\n"
+                (builtins.attrNames
+                  (inputs.nixpkgs.lib.nixosSystem {
+                    inherit system;
+                    modules = [
+                      inputs.self.nixosModules.default
+                      {
+                        hardware.amd-npu = {
+                          enable = true;
+                          enableLemonade = false;
+                          enableROCm = true;
+                          enableVulkan = true;
+                          lemonade.user = "testuser";
+                        };
+                      }
+                    ];
+                  }).config.environment.etc);
+            in
+              pkgs.runCommand "module-eval-lemonade-false" {inherit etcNames;} ''
+                if echo "$etcNames" | grep -q 'lemonade/backends'; then
+                  echo "enableLemonade=false must not create lemonade/backends symlinks"
+                  exit 1
+                fi
+                touch $out
+              '';
           }
           else {
             # Force the nix-darwin module to evaluate and assert the launchd

--- a/modules/amd-npu.nix
+++ b/modules/amd-npu.nix
@@ -4,7 +4,7 @@
   pkgs,
   ...
 }: let
-  inherit (lib) mkEnableOption mkOption mkIf mkDefault types optionalString optional optionals optionalAttrs makeBinPath versionAtLeast concatStringsSep;
+  inherit (lib) mkEnableOption mkOption mkIf mkDefault types optionalString optional optionals optionalAttrs versionAtLeast concatStringsSep;
   cfg = config.hardware.amd-npu;
 
   # The Tauri desktop app is the only part of lemonade that pulls a Rust/npm

--- a/modules/amd-npu.nix
+++ b/modules/amd-npu.nix
@@ -55,13 +55,13 @@
     // optionalAttrs (cfg.enableLemonade && cfg.enableImageGen) {
       "lemonade/backends/sdcpp-cpu".source = "${pkgs.stable-diffusion-cpp}/bin/sd-server";
     }
-    // optionalAttrs cfg.enableROCm {
+    // optionalAttrs (cfg.enableLemonade && cfg.enableROCm) {
       "lemonade/backends/llamacpp-rocm".source = "${pkgs.llama-cpp-rocm}/bin/llama-server";
     }
-    // optionalAttrs (cfg.enableROCm && cfg.enableImageGen) {
+    // optionalAttrs (cfg.enableLemonade && cfg.enableROCm && cfg.enableImageGen) {
       "lemonade/backends/sdcpp-rocm".source = "${pkgs.stable-diffusion-cpp-rocm}/bin/sd-server";
     }
-    // optionalAttrs cfg.enableVulkan {
+    // optionalAttrs (cfg.enableLemonade && cfg.enableVulkan) {
       "lemonade/backends/llamacpp-vulkan".source = "${pkgs.llama-cpp-vulkan}/bin/llama-server";
       "lemonade/backends/whispercpp-vulkan".source = "${pkgs.whisper-cpp-vulkan}/bin/whisper-server";
     };

--- a/modules/amd-npu.nix
+++ b/modules/amd-npu.nix
@@ -227,7 +227,8 @@ in {
       }
       {
         assertion =
-          cfg.gpuMemory.pagePoolSizeGiB == null
+          cfg.gpuMemory.pagePoolSizeGiB
+          == null
           || cfg.gpuMemory.ttmSizeGiB == null
           || cfg.gpuMemory.pagePoolSizeGiB <= cfg.gpuMemory.ttmSizeGiB;
         message = "hardware.amd-npu.gpuMemory.pagePoolSizeGiB must be <= ttmSizeGiB.";
@@ -297,11 +298,12 @@ in {
 
     # System packages.
     #
-    # The GPU-enabled llama-cpp / whisper-cpp variants are listed BEFORE the
-    # CPU variants so that a `llama-server` / `whisper-server` invoked through
-    # PATH points at the GPU build. nixpkgs buildEnv merges packages in
-    # declaration order, and the first package providing a given relative path
-    # wins; declaring CPU first would shadow the GPU binaries.
+    # The llama-cpp / whisper-cpp / stable-diffusion-cpp engines are deliberately
+    # NOT installed here. Each ships its ggml backend .so files in $out/bin, and
+    # putting those on the system PATH makes glib's GIO module loader dlopen them
+    # as plugins and spam "Failed to load module" on every glib app. Nothing needs
+    # them on PATH: lemond reads its backends from the /etc/lemonade/backends/*
+    # symlinks below, and other consumers reference them by store path directly.
     environment.systemPackages =
       [
         pkgs.pciutils
@@ -310,18 +312,7 @@ in {
       ++ optional cfg.enableNPU xrt-combined
       ++ optional cfg.enableFastFlowLM pkgs.fastflowlm
       ++ optional cfg.enableLemonade lemonadePackage
-      ++ optional cfg.enableROCm pkgs.rocmPackages.clr
-      ++ optional cfg.enableROCm pkgs.llama-cpp-rocm
-      ++ optional (cfg.enableROCm && cfg.enableImageGen) pkgs.stable-diffusion-cpp-rocm
-      ++ optionals cfg.enableVulkan [
-        pkgs.llama-cpp-vulkan
-        pkgs.whisper-cpp-vulkan
-      ]
-      ++ optionals cfg.enableLemonade [
-        pkgs.llama-cpp
-        pkgs.whisper-cpp
-      ]
-      ++ optional (cfg.enableLemonade && cfg.enableImageGen) pkgs.stable-diffusion-cpp;
+      ++ optional cfg.enableROCm pkgs.rocmPackages.clr;
 
     # koko (kokoro TTS) is a runtime-downloaded prebuilt ELF that asks for
     # /lib64/ld-linux-x86-64.so.2; nix-ld swaps the stub for a real loader, and


### PR DESCRIPTION
## Problem

`llama-cpp` / `whisper-cpp` / `stable-diffusion-cpp` ship their ggml backend `.so` files in `$out/bin`. Installing those engines into `environment.systemPackages` put the `libggml-*.so` files onto `/run/current-system/sw/bin`, where glib's GIO module loader `dlopen`s them as plugins and logs 'Failed to load module' on every glib app that scans that dir (surfaces in the tmux session-picker popup, and after every `nh switch`). Cosmetic, but noisy.

## Fix

Drop the `llama-cpp`/`whisper-cpp`/`stable-diffusion-cpp` packages from `environment.systemPackages`. Nothing needs them on PATH: `lemond` resolves backends via the `/etc/lemonade/backends/*` symlinks (store paths), and other consumers reference them by store path (e.g. `whisper-cpp-vulkan/bin/whisper-cli`). Kept: pciutils, lshw, xrt, fastflowlm, lemonade, rocmPackages.clr.

## Verification

Built a downstream g5 toplevel (enableLemonade + ROCm + Vulkan, no NPU) against this branch: `sw/bin/libggml*` = 0 files (was 16+); lemonade/lemond present; all /etc/lemonade/backends symlinks intact; build exits 0.

## Trade-off

Bare `llama-server`/`whisper-server` are no longer on the interactive PATH (deliberate before, per the removed comment). Use lemonade, or the store path.