### PR TITLE
chore: bump lemonade 10.9.0 -> 10.10.0

### DIFF
--- a/pkgs/lemonade/darwin.nix
+++ b/pkgs/lemonade/darwin.nix
@@ -15,7 +15,7 @@ in
     # user cache at first run, exactly as the official .pkg does.
     src = fetchurl {
       url = "https://github.com/lemonade-sdk/lemonade/releases/download/v${version}/lemonade-embeddable-${version}-macos-arm64.tar.gz";
-      hash = "sha256-2laEiQCSc6MkW/qgjedgt5sc8CqgVQksXADiGrDwJW4=";
+      hash = "sha256-JIK+lSCWTWbUFf6/6x7nCy4AZn+dm7dg4xIRUS0J80s=";
     };
 
     # The Mach-O binaries are adhoc-signed and link only against system

--- a/pkgs/lemonade/default.nix
+++ b/pkgs/lemonade/default.nix
@@ -38,7 +38,7 @@
     owner = "lemonade-sdk";
     repo = "lemonade";
     rev = "v${version}";
-    hash = "sha256-MbToo4ydBGiWk8pMF2Rw5awLdI+MZQsSQzlv9SQOmy8=";
+    hash = "sha256-HGJ4TNrt7CAxP8RpMLERFRpq4mX9b4ooQTVjCdn+3y8=";
   };
 
   web-app = callPackage ./web-app.nix {inherit src version;};

--- a/pkgs/lemonade/version.nix
+++ b/pkgs/lemonade/version.nix
@@ -2,4 +2,4 @@
 # build (default.nix) and the macOS prebuilt wrap (darwin.nix). The update
 # workflow (scripts/bump-versions.sh) bumps this file and refreshes both the
 # source-tarball hash (default.nix) and the embeddable-bundle hash (darwin.nix).
-"10.9.0"
+"10.10.0"


### PR DESCRIPTION
## Lemonade update

- Lemonade: 10.9.0 -> 10.10.0 ([v10.10.0](https://github.com/lemonade-sdk/lemonade/releases/tag/v10.10.0))

Refreshed the Linux source-tarball hash (`default.nix`) and the macOS embeddable-bundle hash (`darwin.nix`); `version.nix` bumped.

The MTP override (`llamaCppMtpOverride`) is already gone from `flake.nix` (nixpkgs has caught up), so no hand-bump was needed.

**Verified:** `nix build .#lemonade` succeeds on x86_64-linux — including the `web-app`/`tauri-frontend` npm-deps and `tauri-app` cargo vendor, so none of the sub-package lockfile hashes drifted.