### PR TITLE
feat: package ds4 (DeepSeek V4 engine, Strix Halo ROCm backend)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,7 +20,7 @@ jobs:
           name: nix-amd-ai
           authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
       - name: Build all packages
-        run: nix build .#xrt .#xrt-plugin-amdxdna .#fastflowlm .#lemonade
+        run: nix build .#xrt .#xrt-plugin-amdxdna .#fastflowlm .#lemonade .#ds4
       - name: Check flake
         run: nix flake check
       - name: Verify lemond unit (systemd-analyze)

--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ On Apple Silicon (`aarch64-darwin`) the same flake also serves the cross-platfor
 | `llama-cpp-vulkan` | Vulkan-accelerated llama.cpp backend | Built from [ggerganov/llama.cpp](https://github.com/ggerganov/llama.cpp) |
 | `whisper-cpp-vulkan` | Vulkan-accelerated whisper.cpp backend | `pkgs.whisper-cpp.override { vulkanSupport = true; }` |
 | `stable-diffusion-cpp-rocm` | ROCm-accelerated stable-diffusion.cpp backend | `pkgs.stable-diffusion-cpp.override { rocmSupport = true; }` |
+| `ds4` | DeepSeek V4 inference engine, Strix Halo (`gfx1151`) ROCm backend (`ds4`, `ds4-server`, `ds4-bench`, `ds4-eval`, `ds4-agent`) | Built from [antirez/ds4](https://github.com/antirez/ds4) |
 | `gaia` | AMD GAIA agent framework launcher (`gaia`, `gaia-cli`, `gaia-mcp`, `gaia-emr`, `gaia-code`) | `uvx` wrapper around [amd/gaia](https://github.com/amd/gaia) |
 | `benchmark` | Multi-backend benchmark harness | `nix run .#benchmark` |
 
@@ -267,7 +268,16 @@ The wrapper pre-sets `LEMONADE_BASE_URL=http://localhost:13305/api/v1` (matching
 
 Bump the pinned version in `pkgs/gaia/default.nix` when a new GAIA release lands and you want it. CI doesn't auto-bump GAIA today (only lemonade / fastflowlm / xdna are wired into `scripts/check-updates.sh`).
 
-## Which backend should I use?
+## ds4 (DeepSeek V4 on Strix Halo)
+
+[ds4](https://github.com/antirez/ds4) is antirez's self-contained native inference engine for DeepSeek V4. It is deliberately narrow — not a generic GGUF runner — and its ROCm backend targets Strix Halo (`gfx1151`) only, so the package is `x86_64-linux` + AMD-hardware specific and pins `gfx1151` via the `gpuTarget` argument.
+
+```bash
+nix run .#ds4 -- -m /path/to/DeepSeek-V4-Flash.gguf   # interactive chat
+nix shell .#ds4 -c ds4-server --ctx 100000            # OpenAI-compatible server
+```
+
+The engine only; bring your own GGUF (see upstream [`STRIXHALO.md`](https://github.com/antirez/ds4/blob/main/STRIXHALO.md) for the recommended `DeepSeek-V4-Flash` quant and the host GTT/`ttm.pages_limit` kernel tuning). Upstream ships no releases, so `pkgs/ds4/default.nix` pins a commit and is bumped manually — CI builds it but `scripts/check-updates.sh` doesn't track it.
 
 All numbers measured on Strix Point (gfx1150, Radeon 890M iGPU, 64 GiB DDR5-5600). Prompt 256 tokens, generation 128 tokens, 3 iterations after 1 warmup.
 

--- a/flake.nix
+++ b/flake.nix
@@ -78,6 +78,7 @@
           in {
             inherit xrt fastflowlm llama-cpp llama-cpp-vulkan llama-cpp-rocm libwebsockets;
             inherit whisper-cpp-vulkan stable-diffusion-cpp-rocm;
+            ds4 = pinned.callPackage ./pkgs/ds4 {};
             xrt-plugin-amdxdna = pinned.callPackage ./pkgs/xrt-plugin-amdxdna {inherit xrt;};
             lemonade = pinned.callPackage ./pkgs/lemonade {
               inherit fastflowlm llama-cpp-vulkan llama-cpp-rocm libwebsockets;
@@ -118,6 +119,7 @@
         in {
           inherit xrt fastflowlm llama-cpp llama-cpp-vulkan llama-cpp-rocm libwebsockets;
           inherit whisper-cpp-vulkan stable-diffusion-cpp-rocm;
+          ds4 = pkgs.callPackage ./pkgs/ds4 {};
           xrt-plugin-amdxdna = pkgs.callPackage ./pkgs/xrt-plugin-amdxdna {inherit xrt;};
           lemonade = pkgs.callPackage ./pkgs/lemonade {
             inherit fastflowlm llama-cpp-vulkan llama-cpp-rocm libwebsockets;

--- a/pkgs/ds4/default.nix
+++ b/pkgs/ds4/default.nix
@@ -1,0 +1,76 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  rocmPackages,
+  # Strix Halo (Ryzen AI MAX+ 395) is the only host ds4 upstream supports today.
+  gpuTarget ? "gfx1151",
+}:
+stdenv.mkDerivation (finalAttrs: {
+  pname = "ds4";
+  version = "0-unstable-2026-06-17";
+
+  src = fetchFromGitHub {
+    owner = "antirez";
+    repo = "ds4";
+    rev = "80ebbc396aee40eedc1d829222f3362d10fa4c6c";
+    hash = "sha256-Ieuc72GHZs20ModQfnvI5Me31n4Pj+WFYtsuqaKJceo=";
+  };
+
+  # clr ships the hipcc wrapper (+ amdclang++) and the HIP runtime headers.
+  nativeBuildInputs = [rocmPackages.clr];
+
+  buildInputs = [
+    rocmPackages.hipblas
+    rocmPackages.hipblas-common
+    rocmPackages.hipblaslt
+    rocmPackages.hipcub
+    rocmPackages.rocprim
+    rocmPackages.rocwmma
+  ];
+
+  makeFlags = [
+    "strix-halo"
+    "HIPCC=hipcc"
+    "ROCM_ARCH=${gpuTarget}"
+    # Upstream hardcodes -march=native; pin a portable baseline so the binary
+    # is cacheable (the GPU offload arch, not the host CPU, is what matters).
+    "NATIVE_CPU_FLAG=-march=x86-64-v3"
+  ];
+
+  # clr's hipcc does not consume Nix's include/lib search paths, so point it
+  # at the ROCm math libraries explicitly.
+  env = {
+    ROCM_PATH = "${rocmPackages.clr}";
+    HIPCC_COMPILE_FLAGS_APPEND = toString [
+      "-I${rocmPackages.rocwmma}/include"
+      "-I${rocmPackages.hipblaslt}/include"
+      "-I${rocmPackages.hipblas}/include"
+      "-I${rocmPackages.hipblas-common}/include"
+      "-I${rocmPackages.hipcub}/include"
+      "-I${rocmPackages.rocprim}/include"
+    ];
+    HIPCC_LINK_FLAGS_APPEND = toString [
+      "-L${rocmPackages.hipblas}/lib"
+      "-L${rocmPackages.hipblaslt}/lib"
+      "-Wl,-rpath,${rocmPackages.hipblas}/lib"
+      "-Wl,-rpath,${rocmPackages.hipblaslt}/lib"
+    ];
+  };
+
+  enableParallelBuilding = true;
+
+  installPhase = ''
+    runHook preInstall
+    install -Dm755 -t $out/bin ds4 ds4-server ds4-bench ds4-eval ds4-agent
+    runHook postInstall
+  '';
+
+  meta = {
+    description = "Native DeepSeek V4 inference engine with a Strix Halo ROCm backend";
+    homepage = "https://github.com/antirez/ds4";
+    license = lib.licenses.mit;
+    platforms = ["x86_64-linux"];
+    mainProgram = "ds4";
+  };
+})


### PR DESCRIPTION
Packages [antirez/ds4](https://github.com/antirez/ds4) — a self-contained native DeepSeek V4 inference engine with a Strix Halo (`gfx1151`) ROCm backend. Requested in #45.

## What

- New `pkgs/ds4/default.nix` wrapping upstream's `make strix-halo` target; builds `ds4`, `ds4-server`, `ds4-bench`, `ds4-eval`, `ds4-agent`.
- Exposed as `.#ds4` in both flake sites (`perSystem` packages + `overlays.default`).
- Added to the CI build smoke in `build.yml`.
- README: package-table row + a short section on the model/kernel-tuning requirements and manual-bump policy.

## Packaging notes

- `hipcc` comes from `rocmPackages.clr`; the `/opt/rocm` symlinks from upstream's `STRIXHALO.md` are **not** needed under Nix.
- clr's `hipcc` doesn't consume Nix's include/lib search paths, so the ROCm math libs are injected via `HIPCC_{COMPILE,LINK}_FLAGS_APPEND`. AMD path needs `hipblas`, `hipblas-common`, `hipblaslt`, `hipcub`, `rocprim`, `rocwmma`.
- `-march=native` overridden to `x86-64-v3` for a cacheable binary (the GPU offload arch, not the host CPU, is what matters).
- Pinned to a commit (no upstream releases); bumped manually — not wired into `scripts/check-updates.sh`.

## Verification

- `nix build .#ds4` succeeds; all libs resolve (`ldd`), `ds4 --help` runs and lists the `--rocm` backend.
- `nix flake check` green; alejandra-clean.
- ⚠️ **Not runtime-validated on a gfx1151 host** — build + link + `--help` only, no actual inference (no Halo hardware available; same caveat as #42).

Closes #45