### PR TITLE
feat: run ds4-server as a systemd unit (hardware.amd-npu.ds4)

### DIFF
--- a/README.md
+++ b/README.md
@@ -279,6 +279,20 @@ nix shell .#ds4 -c ds4-server --ctx 100000            # OpenAI-compatible server
 
 The engine only; bring your own GGUF (see upstream [`STRIXHALO.md`](https://github.com/antirez/ds4/blob/main/STRIXHALO.md) for the recommended `DeepSeek-V4-Flash` quant and the host GTT/`ttm.pages_limit` kernel tuning). Upstream ships no releases, so `pkgs/ds4/default.nix` pins a commit and is bumped manually — CI builds it but `scripts/check-updates.sh` doesn't track it.
 
+To run `ds4-server` as a managed systemd unit, enable it via the module:
+
+```nix
+hardware.amd-npu.ds4 = {
+  enable = true;
+  user = "youruser";                                  # must be in render + video
+  model = "/var/lib/ds4/DeepSeek-V4-Flash.gguf";       # runtime path, not store-copied
+  ctx = 100000;
+  extraArgs = ["--ssd-streaming" "--kv-disk-dir" "/var/lib/ds4/server-kv"];
+};
+```
+
+Binds `127.0.0.1:8000` by default (`host`/`port`); the unit runs with `render`/`video` GPU access, `LimitMEMLOCK=infinity`, and a writable `/var/lib/ds4` (StateDirectory) for the optional SSD-streaming KV cache. Retarget another AMD GPU with `package = pkgs.ds4.override { gpuTarget = "gfx1103"; }` (experimental — upstream only validates gfx1151).
+
 All numbers measured on Strix Point (gfx1150, Radeon 890M iGPU, 64 GiB DDR5-5600). Prompt 256 tokens, generation 128 tokens, 3 iterations after 1 warmup.
 
 ### Large: Gemma-4-26B-A4B-it-GGUF (~15.7 GB, via `llama-bench`, llama.cpp b8770)

--- a/flake.nix
+++ b/flake.nix
@@ -129,6 +129,7 @@
           };
           gaia = pkgs.callPackage ./pkgs/gaia {};
           lemond-unit = lemondUnit;
+          ds4-server-unit = ds4ServerUnit;
         };
 
         # macOS: server-only Lemonade wrap (Metal backend, fetched at runtime).
@@ -161,6 +162,37 @@
               }
             ];
           }).config.systemd.units."lemond.service".unit;
+
+        # Rendered ds4-server.service for a minimal ds4.enable host — consumed by
+        # the ds4-server-unit-render check.
+        ds4ServerUnit =
+          (inputs.nixpkgs.lib.nixosSystem {
+            inherit system;
+            modules = [
+              inputs.self.nixosModules.default
+              {
+                boot.loader.grub.enable = false;
+                fileSystems."/" = {
+                  device = "/dev/sda1";
+                  fsType = "ext4";
+                };
+                hardware.amd-npu = {
+                  enable = true;
+                  ds4 = {
+                    enable = true;
+                    user = "testuser";
+                    model = "/var/lib/ds4/DeepSeek-V4-Flash.gguf";
+                    ctx = 100000;
+                    extraArgs = ["--ssd-streaming"];
+                  };
+                };
+                users.users.testuser = {
+                  isNormalUser = true;
+                  extraGroups = ["video" "render"];
+                };
+              }
+            ];
+          }).config.systemd.units."ds4-server.service".unit;
       in {
         packages =
           (
@@ -316,6 +348,22 @@
                 || { echo "missing/changed NIX_LD"; exit 1; }
               grep -q 'NIX_LD_LIBRARY_PATH=/run/current-system/sw/share/nix-ld/lib' "$unit" \
                 || { echo "missing/changed NIX_LD_LIBRARY_PATH"; exit 1; }
+              touch $out
+            '';
+
+            # ds4-server assembles its argv from the ds4.* options: the model
+            # path, ctx, host/port, and passthrough extraArgs must all land on
+            # the ExecStart line, and the unit must grant render/video GPU
+            # access plus a writable state dir.
+            ds4-server-unit-render = pkgs.runCommand "ds4-server-unit-render" {} ''
+              unit=${ds4ServerUnit}/ds4-server.service
+              grep -q -- '--model /var/lib/ds4/DeepSeek-V4-Flash.gguf' "$unit" || { echo "missing/changed --model"; exit 1; }
+              grep -q -- '--ctx 100000' "$unit" || { echo "missing/changed --ctx"; exit 1; }
+              grep -q -- '--port 8000' "$unit" || { echo "missing/changed --port"; exit 1; }
+              grep -q -- '--ssd-streaming' "$unit" || { echo "missing extraArgs passthrough"; exit 1; }
+              grep -q 'SupplementaryGroups=video' "$unit" || { echo "missing video group"; exit 1; }
+              grep -q 'SupplementaryGroups=render' "$unit" || { echo "missing render group"; exit 1; }
+              grep -q 'StateDirectory=ds4' "$unit" || { echo "missing StateDirectory"; exit 1; }
               touch $out
             '';
 

--- a/modules/amd-npu.nix
+++ b/modules/amd-npu.nix
@@ -182,6 +182,68 @@ in {
       };
     };
 
+    ds4 = {
+      enable = mkEnableOption "the ds4-server DeepSeek V4 inference server as a systemd unit";
+
+      package = mkOption {
+        type = types.package;
+        default = pkgs.ds4;
+        defaultText = lib.literalExpression "pkgs.ds4";
+        description = ''
+          ds4 package providing `ds4-server`. Override to retarget the ROCm
+          backend, e.g. `pkgs.ds4.override { gpuTarget = "gfx1103"; }`.
+        '';
+      };
+
+      model = mkOption {
+        type = types.nullOr types.str;
+        default = null;
+        example = "/var/lib/ds4/DeepSeek-V4-Flash.gguf";
+        description = ''
+          Path to the DeepSeek V4 GGUF served by ds4-server. A runtime path,
+          deliberately a string so it is not copied into the Nix store.
+          Required when `ds4.enable` is set.
+        '';
+      };
+
+      ctx = mkOption {
+        type = types.nullOr types.ints.positive;
+        default = null;
+        description = "Allocated context tokens (`--ctx`). null leaves the ds4-server default.";
+      };
+
+      host = mkOption {
+        type = types.str;
+        default = "127.0.0.1";
+        description = "Bind address for ds4-server (`--host`).";
+      };
+
+      port = mkOption {
+        type = types.port;
+        default = 8000;
+        description = "Bind port for ds4-server (`--port`).";
+      };
+
+      user = mkOption {
+        type = types.str;
+        description = ''
+          User account to run ds4-server as. Must be in the `render` and
+          `video` groups for ROCm GPU access.
+        '';
+      };
+
+      extraArgs = mkOption {
+        type = types.listOf types.str;
+        default = [];
+        example = ["--ssd-streaming" "--kv-disk-dir" "/var/lib/ds4/server-kv"];
+        description = ''
+          Extra arguments appended to the ds4-server command line — e.g.
+          `--ssd-streaming` with its `--kv-disk-*` flags, or `--threads`. The
+          unit provides a writable `/var/lib/ds4` via StateDirectory.
+        '';
+      };
+    };
+
     gpuMemory = {
       ttmSizeGiB = mkOption {
         type = types.nullOr types.ints.positive;
@@ -224,6 +286,10 @@ in {
       {
         assertion = cfg.gpuMemory.pagePoolSizeGiB == null || cfg.gpuMemory.ttmSizeGiB != null;
         message = "hardware.amd-npu.gpuMemory.pagePoolSizeGiB requires ttmSizeGiB to be set.";
+      }
+      {
+        assertion = !cfg.ds4.enable || cfg.ds4.model != null;
+        message = "hardware.amd-npu.ds4.enable requires hardware.amd-npu.ds4.model (path to a DeepSeek V4 GGUF).";
       }
       {
         assertion =
@@ -367,6 +433,37 @@ in {
         LimitMEMLOCK = "infinity";
         # WhisperServer resolves its writable runtime dir from RUNTIME_DIRECTORY.
         RuntimeDirectory = "lemond";
+      };
+    };
+
+    # ds4-server: OpenAI-compatible DeepSeek V4 server. The package is
+    # self-contained (rpath covers the ROCm libs), so it needs no LD_LIBRARY_PATH
+    # like lemond — only GPU device access (render/video) and a writable state
+    # dir for the optional SSD-streaming KV cache.
+    systemd.services.ds4-server = mkIf cfg.ds4.enable {
+      description = "ds4 DeepSeek V4 inference server";
+      after = ["network-online.target"];
+      wants = ["network-online.target"];
+      wantedBy = ["multi-user.target"];
+      serviceConfig = {
+        Type = "simple";
+        User = cfg.ds4.user;
+        SupplementaryGroups = ["video" "render"];
+        ExecStart = concatStringsSep " " (
+          [
+            "${cfg.ds4.package}/bin/ds4-server"
+            "--model ${cfg.ds4.model}"
+            "--host ${cfg.ds4.host}"
+            "--port ${toString cfg.ds4.port}"
+          ]
+          ++ optional (cfg.ds4.ctx != null) "--ctx ${toString cfg.ds4.ctx}"
+          ++ cfg.ds4.extraArgs
+        );
+        Restart = "on-failure";
+        RestartSec = "5s";
+        KillSignal = "SIGINT";
+        LimitMEMLOCK = "infinity";
+        StateDirectory = "ds4";
       };
     };
   };


### PR DESCRIPTION
Implements the primary scope of #51 — a NixOS module option to run `ds4-server` as a managed systemd unit, mirroring the existing `lemond` service.

## What

- New `hardware.amd-npu.ds4` option group: `enable`, `package`, `model`, `ctx`, `host`, `port`, `user`, `extraArgs`.
- `systemd.services.ds4-server` — `Type=simple`, `KillSignal=SIGINT`, `LimitMEMLOCK=infinity`, `SupplementaryGroups=[video render]` for ROCm GPU access, and `StateDirectory=ds4` (`/var/lib/ds4`) for the optional SSD-streaming KV cache.
- Assertion: `ds4.enable` requires `ds4.model`.
- README: documents the option with a config example.

## Design notes

- **No `LD_LIBRARY_PATH` wiring** (unlike `lemond`): the ds4 package is self-contained — hipcc bakes the ROCm lib rpaths into the binary, so it only needs GPU device access + memlock.
- `model` is `types.str`, not `types.path`, so a runtime GGUF path isn't copied into the Nix store.
- `extraArgs` is the escape hatch for `--ssd-streaming` / `--kv-disk-*` / `--threads` rather than modeling every ds4-server flag.
- `package` lets you retarget another AMD GPU: `pkgs.ds4.override { gpuTarget = "gfx1103"; }` (experimental).

## Verification

- `nix flake check` green, including a new **`ds4-server-unit-render`** check that renders the unit (`.#ds4-server-unit`) and asserts the full argv (`--model/--ctx/--port/--ssd-streaming`) plus the render/video groups and StateDirectory.
- Confirmed the rendered ExecStart: `ds4-server --model … --host 127.0.0.1 --port 8000 --ctx 100000 --ssd-streaming`.
- alejandra-clean.

## Out of scope

gaia — per #51, deferred as a separate open question (its `uvx` runtime-download model makes it a poor systemd citizen). This PR is ds4-server only; #51 stays open to track that decision.

Refs #51