### PR TITLE
fix(module): stop forcing iommu.passthrough=0 for NPU

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,7 +141,7 @@ hardware.amd-npu = {
 
 ## What the module configures
 
-- Kernel params (`iommu.passthrough=0`) and modules (`amdxdna`)
+- Kernel modules (`amdxdna`)
 - Udev rules for NPU device access
 - PAM limits (unlimited memlock for NPU buffer allocation)
 - XRT + plugin merged tree for runtime plugin discovery
@@ -218,12 +218,18 @@ CPU and OS still need their share (the 120/128 example keeps a margin).
 ### `amd_iommu=off` would kill the NPU
 
 The Strix Halo wiki suggests `amd_iommu=off` for a small memory-read speedup.
-**Do not do this on a host that uses the NPU.** amdxdna binds the NPU through
-IOMMU SVA/PASID (`iommu_sva_bind_device`, IOMMU group 25, IOMMU in *Translated*
-mode); `amd_iommu=off` or `iommu.passthrough=1` makes the bind fail
-(`*ERROR* Can not assign PASID` / `SVA get pasid failed`) and the NPU dies. The
-module already pins `iommu.passthrough=0` for this reason. `amd_iommu=off` is
-only viable on a GPU-only host that has given up XDNA.
+**Do not do this on a host that uses the NPU.** amdxdna needs the IOMMU present
+for PASID; with `amd_iommu=off` there is no IOMMU at all and the NPU dies.
+`amd_iommu=off` is only viable on a GPU-only host that has given up XDNA.
+
+The IOMMU default-domain *mode* is a separate knob. amdxdna historically
+required *Translated* mode (SVA/PASID), so the module used to pin
+`iommu.passthrough=0`. Since the June 2026 amdxdna fix (upstream `5b96159`,
+"skip PASID tag in non-SVA mode") the driver no longer tags DMA with an invalid
+PASID under an identity default domain, so the NPU works with `iommu=pt` too.
+The module no longer forces the mode — it leaves the kernel default (Translated
+on NixOS), and hosts that want passthrough for a memory-read win can set
+`iommu=pt` themselves.
 
 ### CPU performance tuning (not implemented — pending A/B)
 

--- a/modules/amd-npu.nix
+++ b/modules/amd-npu.nix
@@ -236,7 +236,6 @@ in {
     ];
 
     # Kernel configuration (NPU-only)
-    boot.kernelParams = optionals cfg.enableNPU ["iommu.passthrough=0"];
     boot.kernelModules = optionals cfg.enableNPU ["amdxdna"];
 
     # GTT pool sizing (opt-in). Raises what's *addressable*, not consumed — no


### PR DESCRIPTION
Drops the forced `iommu.passthrough=0` kernel param from `hardware.amd-npu`.

## Why

amdxdna required IOMMU Translated mode (SVA/PASID) until the June 2026 driver fix ([upstream `5b96159`](https://github.com/amd/xdna-driver/pull/1445), "skip PASID tag in non-SVA mode"), which stops the driver tagging DMA with an invalid PASID under an identity default domain. So the pin was a genuine requirement when it was added, but the driver has outgrown it.

As reported in #49 (Ryzen AI 7 350, kernel 7.1.2), the NPU now runs fine under `iommu=pt`. The forced param only got in the way of users wanting passthrough for a memory-read win.

## Change

- Remove `boot.kernelParams = ... ["iommu.passthrough=0"]` — fall back to the kernel default (Translated on NixOS).
- README: keep the still-true `amd_iommu=off` warning (no IOMMU = no PASID = dead NPU), and document that the default-domain mode is now unforced and `iommu=pt` is available.

No opt-out option needed: with the param gone the system uses the kernel default, and passthrough-seekers set `iommu=pt` themselves.

Closes #49