### PR TITLE
fix(ci): fire build.yml on auto-merged bumps via RELEASE_PAT

### DIFF
--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -135,7 +135,9 @@ jobs:
       # Auto-merge only the clean path: this job already built the 4 packages and
       # ran flake check on the bumped tree, so build success here IS the gate.
       # MTP hand-bumps still build green with a stale override, so they stay for
-      # review. The push to main then triggers build.yml's release job.
+      # review. The merge runs under RELEASE_PAT, not the default GITHUB_TOKEN,
+      # because pushes made by GITHUB_TOKEN do not trigger other workflows — the
+      # resulting push to main must fire build.yml (darwin build + release job).
       - name: Auto-merge clean bumps
         if: |
           steps.pr.outputs.pr_url != '' &&
@@ -143,5 +145,5 @@ jobs:
           steps.build.outputs.failed == '' &&
           steps.check.outputs.mtp_override_needs_update != 'true'
         env:
-          GH_TOKEN: ${{ github.token }}
+          GH_TOKEN: ${{ secrets.RELEASE_PAT }}
         run: gh pr merge --squash --delete-branch "${{ steps.pr.outputs.pr_url }}"


### PR DESCRIPTION
## Problem

Weekly bump PRs are auto-merged by the `update.yml` job using the default `GITHUB_TOKEN`. Pushes made by `GITHUB_TOKEN` **do not trigger other workflows** (GitHub's anti-recursion rule), so `build.yml` never ran on the auto-merged commits. Two things silently broke for every bot bump:

- **No release** was cut — the `release` job lives in `build.yml`, which never fired. Last release stopped at Lemonade 10.10.0 (the last *human*-merged bump); #44, #47, #54, #55 produced no release.
- **The darwin build was never exercised** — `build-darwin` (macOS `nix build .#lemonade .#benchmark`) only runs on real push/PR events.

Auto-release *appeared* to work only because earlier bumps (e.g. #43) were merged by a human, whose push does trigger `build.yml`.

## Fix

Run the auto-merge step under a fine-grained `RELEASE_PAT` instead of `GITHUB_TOKEN`, so the merge push is seen by `build.yml` exactly like a human merge — restoring both the darwin build gate and the release job.

## Required before this works

Add a repo secret `RELEASE_PAT` — a fine-grained PAT scoped to this repo with **Contents: RW** and **Pull requests: RW**.

lemonade 11.0.0 itself builds fine on both platforms; this only fixes the CI plumbing.