### PR TITLE
fix(lemonade): disable TheRock ROCm so it can't shadow nix backend libs

### DIFF
--- a/pkgs/lemonade/default.nix
+++ b/pkgs/lemonade/default.nix
@@ -137,6 +137,20 @@ in stdenv.mkDerivation {
                     }
                     return true;'
 
+    # Never fetch lemonade's downloaded "TheRock" ROCm runtime: it prepends its
+    # lib/ to LD_LIBRARY_PATH for rocm-stable, shadowing our nix sd-server /
+    # llama-server's own ROCm libs (same sonames) with TheRock copies that need
+    # libatomic.so.1 — absent on NixOS, so the loader exits 127 (#57). Forcing
+    # will_install_therock() false skips the download; with no TheRock dir,
+    # get_therock_lib_path() returns "" and every injection site falls back to
+    # the binary's RUNPATH. Keep the therock key so get_therock_version() lookups
+    # don't throw.
+    substituteInPlace src/cpp/server/backend_manager.cpp \
+      --replace-fail \
+        'bool will_install_therock(const std::string& os, const json& backend_versions) {' \
+        'bool will_install_therock(const std::string& os, const json& backend_versions) {
+    return false;  // nix-amd-ai#57: ship self-contained ROCm binaries, never fetch TheRock'
+
     # Pin backend_versions.json to whatever fastflowlm / llama-cpp /
     # whisper-cpp / sd-cpp builds we ship, so lemonade's "installed vs
     # needs update" check stays satisfied and it doesn't try to download


### PR DESCRIPTION
Fixes #57 — image generation on the ROCm backend died instantly with `exit code 127`.

## Root cause

The `127` is a hidden dynamic-loader failure (lemonade sends `sd-server`s stderr to `/dev/null` unless the log level is `debug`). The real error:

```
sdcpp-rocm: error while loading shared libraries: libatomic.so.1: cannot open shared object file
```

1. For the `rocm-stable` image channel, lemonade downloads its own **TheRock** ROCm runtime into `~/.cache/lemonade/bin/therock/<arch>/` and **prepends its `lib/` to `LD_LIBRARY_PATH`** (for both sd-cpp and llamacpp).
2. Our nix `sd-server` / `llama-server` carry the same sonames (`libamdhip64.so.7`, `librocblas.so.5`, `libhipblas.so.3`), so `ld.so` loads TheRock`s copies instead of the nixpkgs ones they were linked against.
3. TheRock`s `librocprofiler-sdk*` need `libatomic.so.1`, absent on NixOS → loader exits `127`.

## Fix

Force `will_install_therock()` to `false` in `postPatch`. No download → no TheRock dir → `get_therock_lib_path()` returns `""` → every injection site (sd-cpp, llamacpp, upscale) falls back to the binary`s own RUNPATH. The `therock` key stays in `backend_versions.json` so `get_therock_version()` asset-name lookups don`t throw. This also skips the pointless multi-GB TheRock download.

## Validation

Reproduced the exact `127` on a gfx1150 host, then ran the patched `lemond`: it renders a 512×512 SD-Turbo image on `backend: rocm` in ~10 s, **no TheRock download, no 127**.

## Notes

- Upstream lemonade should ideally skip TheRock only when the backend binary is externally provided (explicit `*_bin` path) rather than a blanket disable; the blanket form is correct for this flake. Follow-up.
- Separate issue seen while debugging: a stale `~/.cache/lemonade/config.json` can hold GC`d raw store paths from the pre-v10.7.0 env→config era, surfacing as `500 "sdcpp.rocm_bin path does not exist"`. Clearing that file lets the current `/etc/lemonade/backends/*` defaults take over. Not addressed here.