### PR TITLE
feat(module): add Vulkan stable-diffusion.cpp backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,7 +158,7 @@ The lemonade source build deliberately doesn't bundle backend `llama-server` / `
 |---|---|
 | `enableLemonade` | CPU recipes always-on: `llamacpp:cpu`, `whispercpp:cpu`, `sd-cpp:cpu` (when `enableImageGen`) |
 | `enableROCm` | `llamacpp:rocm`, `llamacpp:system` (via `LEMONADE_GGML_HIP_PATH`), `sd-cpp:rocm` (when `enableImageGen`) |
-| `enableVulkan` | `llamacpp:vulkan`, `whispercpp:vulkan` |
+| `enableVulkan` | `llamacpp:vulkan`, `whispercpp:vulkan`, `sd-cpp:vulkan` (when `enableImageGen`) |
 | `enableImageGen` (default true) | Gates all `sd-cpp:*` packages; turn off for ~150 MB CPU / ~1.5 GB ROCm savings on headless LLM-only hosts |
 
 Omni models (e.g. `LMX-Omni-*`) pull in two backends that need extra host plumbing the module wires automatically with `enableLemonade` ([#33](https://github.com/noamsto/nix-amd-ai/issues/33)): `whispercpp` resolves its writable runtime dir from the unit's `RuntimeDirectory`, and the runtime-downloaded kokoro TTS binary is a foreign prebuilt ELF, so the module enables `nix-ld` (its default libraries already cover koko's openssl + gcc-libs) and re-exports `NIX_LD*` into the `lemond` service. nix-ld is set via `mkDefault`, so hosts managing it themselves can opt out.

--- a/flake.nix
+++ b/flake.nix
@@ -75,14 +75,15 @@
             llama-cpp-rocm = pinned.llama-cpp-rocm;
             whisper-cpp-vulkan = pinned.whisper-cpp.override {vulkanSupport = true;};
             stable-diffusion-cpp-rocm = pinned.stable-diffusion-cpp.override {rocmSupport = true;};
+            stable-diffusion-cpp-vulkan = pinned.stable-diffusion-cpp.override {vulkanSupport = true;};
           in {
             inherit xrt fastflowlm llama-cpp llama-cpp-vulkan llama-cpp-rocm libwebsockets;
-            inherit whisper-cpp-vulkan stable-diffusion-cpp-rocm;
+            inherit whisper-cpp-vulkan stable-diffusion-cpp-rocm stable-diffusion-cpp-vulkan;
             ds4 = pinned.callPackage ./pkgs/ds4 {};
             xrt-plugin-amdxdna = pinned.callPackage ./pkgs/xrt-plugin-amdxdna {inherit xrt;};
             lemonade = pinned.callPackage ./pkgs/lemonade {
               inherit fastflowlm llama-cpp-vulkan llama-cpp-rocm libwebsockets;
-              inherit whisper-cpp-vulkan stable-diffusion-cpp-rocm;
+              inherit whisper-cpp-vulkan stable-diffusion-cpp-rocm stable-diffusion-cpp-vulkan;
               inherit (pinned) whisper-cpp stable-diffusion-cpp;
             };
             gaia = pinned.callPackage ./pkgs/gaia {};
@@ -115,15 +116,16 @@
           llama-cpp-rocm = pkgs.llama-cpp-rocm;
           whisper-cpp-vulkan = pkgs.whisper-cpp.override {vulkanSupport = true;};
           stable-diffusion-cpp-rocm = pkgs.stable-diffusion-cpp.override {rocmSupport = true;};
+          stable-diffusion-cpp-vulkan = pkgs.stable-diffusion-cpp.override {vulkanSupport = true;};
           libwebsockets = libwebsocketsOverride pkgs;
         in {
           inherit xrt fastflowlm llama-cpp llama-cpp-vulkan llama-cpp-rocm libwebsockets;
-          inherit whisper-cpp-vulkan stable-diffusion-cpp-rocm;
+          inherit whisper-cpp-vulkan stable-diffusion-cpp-rocm stable-diffusion-cpp-vulkan;
           ds4 = pkgs.callPackage ./pkgs/ds4 {};
           xrt-plugin-amdxdna = pkgs.callPackage ./pkgs/xrt-plugin-amdxdna {inherit xrt;};
           lemonade = pkgs.callPackage ./pkgs/lemonade {
             inherit fastflowlm llama-cpp-vulkan llama-cpp-rocm libwebsockets;
-            inherit whisper-cpp-vulkan stable-diffusion-cpp-rocm;
+            inherit whisper-cpp-vulkan stable-diffusion-cpp-rocm stable-diffusion-cpp-vulkan;
             whisper-cpp = pkgs.whisper-cpp;
             stable-diffusion-cpp = pkgs.stable-diffusion-cpp;
           };

--- a/modules/amd-npu.nix
+++ b/modules/amd-npu.nix
@@ -64,6 +64,9 @@
     // optionalAttrs (cfg.enableLemonade && cfg.enableVulkan) {
       "lemonade/backends/llamacpp-vulkan".source = "${pkgs.llama-cpp-vulkan}/bin/llama-server";
       "lemonade/backends/whispercpp-vulkan".source = "${pkgs.whisper-cpp-vulkan}/bin/whisper-server";
+    }
+    // optionalAttrs (cfg.enableLemonade && cfg.enableVulkan && cfg.enableImageGen) {
+      "lemonade/backends/sdcpp-vulkan".source = "${pkgs.stable-diffusion-cpp-vulkan}/bin/sd-server";
     };
 
   # defaults.json seed that lemonade's get_defaults() merges over its packaged
@@ -87,7 +90,8 @@
     // optionalAttrs cfg.enableImageGen {
       sdcpp =
         {cpu_bin = lemonadeBackendBin "sdcpp-cpu";}
-        // optionalAttrs cfg.enableROCm {rocm_bin = lemonadeBackendBin "sdcpp-rocm";};
+        // optionalAttrs cfg.enableROCm {rocm_bin = lemonadeBackendBin "sdcpp-rocm";}
+        // optionalAttrs cfg.enableVulkan {vulkan_bin = lemonadeBackendBin "sdcpp-vulkan";};
     };
   lemonadeDefaultsFile = (pkgs.formats.json {}).generate "lemonade-defaults.json" lemonadeDefaults;
 in {
@@ -133,10 +137,10 @@ in {
       type = types.bool;
       default = true;
       description = ''
-        Whether to wire stable-diffusion.cpp recipes (sd-cpp:cpu and, when
-        enableROCm is true, sd-cpp:rocm) into lemonade. Disable to drop
-        ~150 MB CPU-only / ~1.5 GB with ROCm from the closure if you only
-        use lemonade for LLM inference.
+        Whether to wire stable-diffusion.cpp recipes (sd-cpp:cpu, plus
+        sd-cpp:rocm when enableROCm and sd-cpp:vulkan when enableVulkan) into
+        lemonade. Disable to drop ~150 MB CPU-only / ~1.5 GB with ROCm from
+        the closure if you only use lemonade for LLM inference.
       '';
     };
 

--- a/pkgs/lemonade/default.nix
+++ b/pkgs/lemonade/default.nix
@@ -27,6 +27,7 @@
   whisper-cpp-vulkan,
   stable-diffusion-cpp,
   stable-diffusion-cpp-rocm,
+  stable-diffusion-cpp-vulkan,
   # Default-on opt-out flags. Headless / server-only consumers can flip these
   # off via .override to skip the npm/Rust builds and shrink the closure.
   withWebApp ? true,
@@ -165,7 +166,8 @@ in stdenv.mkDerivation {
           | .whispercpp.cpu = "v${whisper-cpp.version}"
           | .whispercpp.vulkan = "v${whisper-cpp-vulkan.version}"
           | ."sd-cpp".cpu = "${stable-diffusion-cpp.version}"
-          | ."sd-cpp"."rocm-stable" = "${stable-diffusion-cpp-rocm.version}"' \
+          | ."sd-cpp"."rocm-stable" = "${stable-diffusion-cpp-rocm.version}"
+          | ."sd-cpp".vulkan = "${stable-diffusion-cpp-vulkan.version}"' \
         src/cpp/resources/backend_versions.json > src/cpp/resources/backend_versions.json.tmp
       mv src/cpp/resources/backend_versions.json.tmp src/cpp/resources/backend_versions.json
     fi


### PR DESCRIPTION
Adds a **Vulkan** `stable-diffusion.cpp` backend so image generation has a fast, arch-agnostic GPU path — not just `cpu` + `rocm`.

## Why

- Vulkan (RADV) is the recommended AMD GPU path and is arch-agnostic; unlike nixpkgs ROCm 7.2.3 (which faults on gfx1151 / Strix Halo), it carries no arch-specific runtime risk.
- Directly helps the #57 case: a Strix Halo user gets a reliable GPU image-gen path even where the ROCm backend is fragile. Falls back cleanly from `sdcpp:rocm`.

## Change

Mirrors the existing `whisper-cpp-vulkan` / `llama-cpp-vulkan` wiring exactly:
- `stable-diffusion-cpp-vulkan = stable-diffusion-cpp.override { vulkanSupport = true; }` in both overlay + perSystem
- version-pinned in `backend_versions.json` (the `sd-cpp.vulkan` key)
- wired into lemonade via the `sdcpp-vulkan` `/etc/lemonade/backends` symlink + `defaults.json` `sdcpp.vulkan_bin`, gated on `enableVulkan && enableImageGen`
- option/README docs updated

The Vulkan build is Hydra-cached (substitutes from cache.nixos.org), so no new Cachix build burden.

## Validation

- `nix flake check` green (incl. `module-eval-vulkan-true`); `.#stable-diffusion-cpp-vulkan` + `.#lemonade` build.
- **End-to-end:** ran the built `lemond` with sd-cpp routed to Vulkan — `HTTP 200`, log shows `Starting server on port 8001 (backend: vulkan)`, generated a real 512x512 SD-Turbo image (`libvulkan`-linked `sd-server`, RADV device).

Context: emerged from the TheRock/ROCm evaluation — Vulkan beats even latest ROCm for short-context/image workloads, so a Vulkan image-gen path is the right robustness win independent of the (parked) TheRock question.