### PR TITLE
fix(module): seed flm.prefer_system so lemonade finds the PATH flm

### DIFF
--- a/README.md
+++ b/README.md
@@ -258,13 +258,12 @@ installed", and lists no FLM models even after `flm pull`. The module now seeds
 
 A **cached `~/.cache/lemonade/config.json` wins over that seed** (lemonade merges
 user config over defaults), so hosts that ran an older lemonade keep the stale
-`prefer_system: false`. Fix an existing host once, after rebuilding:
+`prefer_system: false`. Fix an existing host once, after rebuilding, by deleting
+the cached config so the module's defaults reseed it:
 
 ```bash
-# either flip the flag in place…
-jq '.flm.prefer_system = true' ~/.cache/lemonade/config.json | sponge ~/.cache/lemonade/config.json
+rm ~/.cache/lemonade/config.json
 sudo systemctl restart lemond
-# …or delete config.json to let the module's defaults reseed it
 ```
 
 See [#62](https://github.com/noamsto/nix-amd-ai/issues/62).

--- a/README.md
+++ b/README.md
@@ -248,6 +248,27 @@ confirms whether the wiki's numbers reproduce on Strix Point. Tracked in
 
 ## Troubleshooting
 
+### FLM models don't appear / `flm:npu` reports "not installed" after enabling FastFlowLM
+
+Lemonade v10.10.0 stopped auto-discovering a `flm` on `PATH`; it now only looks
+there when `flm.prefer_system` is set in `config.json`. Without it, `lemond`
+ignores the nix-provided `flm`, marks the NPU backend `installable`/"not
+installed", and lists no FLM models even after `flm pull`. The module now seeds
+`flm.prefer_system = true` (with `enableFastFlowLM`), so fresh installs work.
+
+A **cached `~/.cache/lemonade/config.json` wins over that seed** (lemonade merges
+user config over defaults), so hosts that ran an older lemonade keep the stale
+`prefer_system: false`. Fix an existing host once, after rebuilding:
+
+```bash
+# either flip the flag in place…
+jq '.flm.prefer_system = true' ~/.cache/lemonade/config.json | sponge ~/.cache/lemonade/config.json
+sudo systemctl restart lemond
+# …or delete config.json to let the module's defaults reseed it
+```
+
+See [#62](https://github.com/noamsto/nix-amd-ai/issues/62).
+
 ### `amdxdna ... aie2_get_info: Not supported request parameter N` in dmesg/journald
 
 Harmless. `aie2_get_info` handles the NPU's `GET_INFO` ioctl, and the mainline `amdxdna` driver implements only a subset of query types (AIE status/version/metadata, clock, hw-contexts). When userspace (`xrt-smi`, a system monitor, or the lemonade/FastFlowLM init path) probes a power/sensor/telemetry param the driver doesn't implement yet, it returns `-EOPNOTSUPP` and logs that `*ERROR*` line — often on a timer, so it repeats. NPU inference is unaffected. Upstream is filling in the missing queries (power reporting ~Linux 7.1, hwmon exposure tracked in [xdna-driver#323](https://github.com/amd/xdna-driver/issues/323)); a newer kernel makes the line disappear.

--- a/modules/amd-npu.nix
+++ b/modules/amd-npu.nix
@@ -84,6 +84,12 @@
         {cpu_bin = lemonadeBackendBin "whispercpp-cpu";}
         // optionalAttrs cfg.enableVulkan {vulkan_bin = lemonadeBackendBin "whispercpp-vulkan";};
     }
+    // optionalAttrs cfg.enableFastFlowLM {
+      # v10.10.0 gates FLM-on-PATH discovery behind this flag; without it lemond
+      # ignores the flm we put on its PATH and reports the NPU backend as "not
+      # installed", so no FLM models list. See noamsto/nix-amd-ai#62.
+      flm.prefer_system = true;
+    }
     // optionalAttrs cfg.enableImageGen {
       sdcpp =
         {cpu_bin = lemonadeBackendBin "sdcpp-cpu";}


### PR DESCRIPTION
Fixes #62.

## Problem

Lemonade **v10.10.0** gates FLM-on-PATH discovery behind a new config flag: `find_flm_in_path()` returns nothing unless `flm.prefer_system` is `true` in `config.json`. The module puts `flm` on lemond's PATH (via `pathList` + `systemPackages`) but never set the flag, so `check_install` reports the NPU backend as **not installed** (`state: installable`) and **no FLM models list** even after `flm pull`.

Reproduced live on a Strix Point host (lemonade 10.10.0), not just the reporter's Halo.

## Fix

Seed `flm.prefer_system = true` in the generated lemonade defaults (gated on `enableFastFlowLM`) — the upstream-intended knob for a distro/Nix system-packaged `flm`.

## Verified

After the fix + `lemond` restart, the FLM backend flips `installable → installed` and models list:

```
$ curl -s localhost:PORT/api/v1/system-info | jq .recipes.flm.backends.npu.state
"installed"
$ curl -s localhost:PORT/api/v1/models | jq "[.data[]|select(.recipe==\"flm\").id]"
["llama3.2-1b-FLM","qwen3-8b-FLM","gpt-oss-20b-FLM", ...]   # 9 models
```

## Migration note

A cached `config.json` with `prefer_system: false` wins over the seed (`merge(defaults, loaded)`), so existing hosts need `rm ~/.cache/lemonade/config.json` once (documented in the README troubleshooting section). Fresh installs get it automatically.

https://claude.ai/code/session_01Jxd7dRGeQvKTfd1cPEgG6j