### PR TITLE
feat(vllm): vLLM ROCm backend via TheRock prebuilt

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,11 +158,25 @@ The lemonade source build deliberately doesn't bundle backend `llama-server` / `
 | `enableLemonade` | CPU recipes always-on: `llamacpp:cpu`, `whispercpp:cpu`, `sd-cpp:cpu` (when `enableImageGen`) |
 | `enableROCm` | `llamacpp:rocm`, `llamacpp:system` (via `LEMONADE_GGML_HIP_PATH`), `sd-cpp:rocm` (when `enableImageGen`) |
 | `enableVulkan` | `llamacpp:vulkan`, `whispercpp:vulkan` |
+| `enableVllm` (default false) | `vllm:rocm` from the `lemonade-sdk/vllm-rocm` prebuilt (requires `enableROCm`); pick the GPU target with `vllmGpuTarget` (`gfx1150`/`gfx1151`). Experimental, ~7.6 GB closure — see below |
 | `enableImageGen` (default true) | Gates all `sd-cpp:*` packages; turn off for ~150 MB CPU / ~1.5 GB ROCm savings on headless LLM-only hosts |
 
 Omni models (e.g. `LMX-Omni-*`) pull in two backends that need extra host plumbing the module wires automatically with `enableLemonade` ([#33](https://github.com/noamsto/nix-amd-ai/issues/33)): `whispercpp` resolves its writable runtime dir from the unit's `RuntimeDirectory`, and the runtime-downloaded kokoro TTS binary is a foreign prebuilt ELF, so the module enables `nix-ld` (its default libraries already cover koko's openssl + gcc-libs) and re-exports `NIX_LD*` into the `lemond` service. nix-ld is set via `mkDefault`, so hosts managing it themselves can opt out.
 
-Lemonade v10.4.0 added an experimental `llamacpp:vllm` (vLLM ROCm) backend for Strix Halo / Strix Point on Linux. We don't wire it: on Strix Point gfx1150 our benchmarks already show Vulkan ahead of ROCm for both prefill and decode, vLLM's batching wins don't apply to single-user lemonade workloads, and upstream still distributes it as a TheRock-style prebuilt blob with no env-var migration. Revisit when it leaves experimental, when a Strix Halo host lands here, or if anyone benchmarks it past Vulkan on gfx1150.
+`enableVllm` wires the experimental `vllm:rocm` backend, repackaged from the
+upstream `lemonade-sdk/vllm-rocm` prebuilt ([#63](https://github.com/noamsto/nix-amd-ai/issues/63)).
+Building vLLM + ROCm from source isn't viable here — nixpkgs `rocmPackages`
+trails ROCm 7.15 and lacks the Strix gfx targets — so we relocate their portable
+Python + torch + TheRock-ROCm bundle instead (interpreter-patched, not
+autoPatchelf'd, which would inject mismatched nixpkgs libs and segfault torch).
+It's off by default and adds a ~7.6 GB closure with no binary-cache substituter.
+
+Validated on gfx1150 (standalone and through lemonade's OpenAI API); the
+`gfx1151` (Strix Halo) target is pinned and builds but hasn't been run on a Halo
+host yet. On gfx1150 our benchmarks still put Vulkan ahead of ROCm and vLLM's
+batching doesn't help single-user workloads, so `enableVllm` mainly matters on
+gfx1151 (where the Vulkan-fills-VRAM-first freeze on X11 makes the ROCm path
+worthwhile) or for vLLM-specific features.
 
 Vanilla v10.5.0 ignores these env vars on NixOS for several reasons that this flake patches in-tree (see `pkgs/lemonade/default.nix:postPatch`, [issue #5](https://github.com/noamsto/nix-amd-ai/issues/5), upstream [lemonade-sdk/lemonade#1791](https://github.com/lemonade-sdk/lemonade/issues/1791)):
 

--- a/flake.nix
+++ b/flake.nix
@@ -81,6 +81,7 @@
               inherit (pinned) whisper-cpp stable-diffusion-cpp;
             };
             gaia = pinned.callPackage ./pkgs/gaia {};
+            vllm-rocm = pinned.callPackage ./pkgs/vllm-rocm {};
           };
 
         nixosModules.default = {
@@ -122,6 +123,7 @@
             stable-diffusion-cpp = pkgs.stable-diffusion-cpp;
           };
           gaia = pkgs.callPackage ./pkgs/gaia {};
+          vllm-rocm = pkgs.callPackage ./pkgs/vllm-rocm {};
           lemond-unit = lemondUnit;
         };
 

--- a/flake.nix
+++ b/flake.nix
@@ -252,6 +252,39 @@
                 ];
               }).config.system.build.etc;
 
+            # enableVllm wiring: evaluate the module and build the generated
+            # lemonade defaults (asserts pass, vllm.rocm_bin seeded, global_timeout
+            # bumped off 0). Targets the defaults JSON rather than system.build.etc
+            # on purpose — the latter would realize the 7.6 GB vllm-rocm bundle,
+            # which no substituter serves.
+            module-eval-vllm =
+              (inputs.nixpkgs.lib.nixosSystem {
+                inherit system;
+                modules = [
+                  inputs.self.nixosModules.default
+                  {
+                    boot.loader.grub.enable = false;
+                    fileSystems."/" = {
+                      device = "/dev/sda1";
+                      fsType = "ext4";
+                    };
+                    hardware.amd-npu = {
+                      enable = true;
+                      enableNPU = false;
+                      enableFastFlowLM = false;
+                      enableLemonade = true;
+                      enableROCm = true;
+                      enableVllm = true;
+                      lemonade.user = "testuser";
+                    };
+                    users.users.testuser = {
+                      isNormalUser = true;
+                      extraGroups = ["video" "render"];
+                    };
+                  }
+                ];
+              }).config.systemd.services.lemond.environment.LEMONADE_DEFAULTS_PATH;
+
             # GTT headroom: configured system emits the ttm modprobe line with
             # GiB→page conversion; default system emits no ttm line.
             module-eval-gtt = let

--- a/modules/amd-npu.nix
+++ b/modules/amd-npu.nix
@@ -152,7 +152,7 @@ in {
       type = types.bool;
       default = false;
       description = ''
-        Whether to wire the vLLM ROCm backend (llamacpp:vllm) into lemonade,
+        Whether to wire the vLLM ROCm backend (vllm:rocm) into lemonade,
         repackaged from the upstream lemonade-sdk/vllm-rocm prebuilt. Requires
         enableROCm. Strix Halo (gfx1151) needs a kernel with the CWSR fix;
         lemonade reports vllm:rocm as unsupported otherwise. Experimental —

--- a/modules/amd-npu.nix
+++ b/modules/amd-npu.nix
@@ -77,7 +77,14 @@
   # their env hook when v10.7.0 removed migrate_from_env.
   lemonadeDefaults =
     {
-      global_timeout = 0;
+      # 0 disables lemond's 300s request cutoff for llama.cpp (lemonade#1364).
+      # But vLLM passes this same value as its startup-readiness timeout, where
+      # 0 means "0 attempts" and the server never gets time to boot — so give it
+      # a large finite window instead. See noamsto/nix-amd-ai#63.
+      global_timeout =
+        if cfg.enableVllm
+        then 3600
+        else 0;
       llamacpp =
         {
           args = "--flash-attn ${cfg.lemonade.flashAttn}";

--- a/modules/amd-npu.nix
+++ b/modules/amd-npu.nix
@@ -13,6 +13,8 @@
   # build path. See noamsto/nix-amd-ai#28.
   lemonadePackage = pkgs.lemonade.override {withDesktopApp = cfg.lemonade.desktopApp.enable;};
 
+  vllmPkg = pkgs.vllm-rocm.override {gpuTarget = cfg.vllmGpuTarget;};
+
   # 4096-byte pages: pages = GiB * 1024^3 / 4096 = GiB * 262144.
   gttPages = gib: gib * 262144;
 
@@ -61,6 +63,9 @@
     // optionalAttrs (cfg.enableLemonade && cfg.enableROCm && cfg.enableImageGen) {
       "lemonade/backends/sdcpp-rocm".source = "${pkgs.stable-diffusion-cpp-rocm}/bin/sd-server";
     }
+    // optionalAttrs (cfg.enableLemonade && cfg.enableROCm && cfg.enableVllm) {
+      "lemonade/backends/vllm-rocm".source = "${vllmPkg}/bin/vllm-server";
+    }
     // optionalAttrs (cfg.enableLemonade && cfg.enableVulkan) {
       "lemonade/backends/llamacpp-vulkan".source = "${pkgs.llama-cpp-vulkan}/bin/llama-server";
       "lemonade/backends/whispercpp-vulkan".source = "${pkgs.whisper-cpp-vulkan}/bin/whisper-server";
@@ -88,6 +93,9 @@
       sdcpp =
         {cpu_bin = lemonadeBackendBin "sdcpp-cpu";}
         // optionalAttrs cfg.enableROCm {rocm_bin = lemonadeBackendBin "sdcpp-rocm";};
+    }
+    // optionalAttrs (cfg.enableROCm && cfg.enableVllm) {
+      vllm.rocm_bin = lemonadeBackendBin "vllm-rocm";
     };
   lemonadeDefaultsFile = (pkgs.formats.json {}).generate "lemonade-defaults.json" lemonadeDefaults;
 in {
@@ -137,6 +145,28 @@ in {
         enableROCm is true, sd-cpp:rocm) into lemonade. Disable to drop
         ~150 MB CPU-only / ~1.5 GB with ROCm from the closure if you only
         use lemonade for LLM inference.
+      '';
+    };
+
+    enableVllm = mkOption {
+      type = types.bool;
+      default = false;
+      description = ''
+        Whether to wire the vLLM ROCm backend (llamacpp:vllm) into lemonade,
+        repackaged from the upstream lemonade-sdk/vllm-rocm prebuilt. Requires
+        enableROCm. Strix Halo (gfx1151) needs a kernel with the CWSR fix;
+        lemonade reports vllm:rocm as unsupported otherwise. Experimental —
+        see noamsto/nix-amd-ai#63.
+      '';
+    };
+
+    vllmGpuTarget = mkOption {
+      type = types.enum ["gfx1150" "gfx1151"];
+      default = "gfx1150";
+      description = ''
+        Which lemonade-sdk/vllm-rocm prebuilt to install: gfx1150 (Strix Point)
+        or gfx1151 (Strix Halo). Each bundles a TheRock ROCm built for that
+        exact target.
       '';
     };
 
@@ -220,6 +250,10 @@ in {
       {
         assertion = !cfg.enableFastFlowLM || cfg.enableNPU;
         message = "hardware.amd-npu.enableFastFlowLM requires enableNPU = true (FastFlowLM runs on the NPU).";
+      }
+      {
+        assertion = !cfg.enableVllm || (cfg.enableROCm && cfg.enableLemonade);
+        message = "hardware.amd-npu.enableVllm requires enableROCm and enableLemonade = true (vLLM runs on the ROCm GPU under lemonade).";
       }
       {
         assertion = cfg.gpuMemory.pagePoolSizeGiB == null || cfg.gpuMemory.ttmSizeGiB != null;

--- a/pkgs/vllm-rocm/default.nix
+++ b/pkgs/vllm-rocm/default.nix
@@ -1,0 +1,92 @@
+# vLLM ROCm for AMD Strix (gfx1150/gfx1151), repackaged from the upstream
+# lemonade-sdk/vllm-rocm prebuilt. We relocate their portable TheRock ROCm +
+# torch + vLLM bundle rather than build vLLM from source: nixpkgs rocmPackages
+# is far behind ROCm 7.15 and lacks the Strix gfx targets. Lemonade launches the
+# resulting `vllm-server` via the `vllm.rocm_bin` config override wired in the
+# NixOS module. See noamsto/nix-amd-ai#63.
+{
+  lib,
+  stdenv,
+  fetchurl,
+  autoPatchelfHook,
+  makeWrapper,
+  zlib,
+  zstd,
+  xz,
+  numactl,
+  libdrm,
+  ncurses,
+  elfutils,
+  openssl,
+  libxml2,
+  libGL,
+  gpuTarget ? "gfx1150",
+}: let
+  sources = import ./sources.nix;
+  src =
+    sources.${gpuTarget}
+    or (throw "vllm-rocm: no prebuilt for gpuTarget '${gpuTarget}' (have: ${lib.concatStringsSep ", " (lib.attrNames sources)})");
+  parts = map (p: fetchurl {inherit (p) url hash;}) src.parts;
+in
+  stdenv.mkDerivation {
+    pname = "vllm-rocm";
+    inherit (src) version;
+
+    # Two <2 GB GitHub assets that concatenate into one .tar.gz.
+    srcs = parts;
+
+    nativeBuildInputs = [autoPatchelfHook makeWrapper];
+
+    # External libs the bundled ELFs need; the ROCm/torch .so ship inside the
+    # bundle and resolve intra-tree once its own lib dirs are on the runpath.
+    buildInputs = [
+      zlib
+      zstd
+      xz
+      numactl
+      libdrm
+      ncurses
+      elfutils
+      openssl
+      libxml2
+      libGL
+      stdenv.cc.cc.lib
+    ];
+
+    # The bundle carries CUDA/other-vendor stubs it never dlopens on this path;
+    # don't fail the build over their absent deps.
+    autoPatchelfIgnoreMissingDeps = ["*"];
+
+    unpackPhase = ''
+      runHook preUnpack
+      cat ${lib.concatStringsSep " " parts} | tar xz
+      runHook postUnpack
+    '';
+
+    dontConfigure = true;
+    dontBuild = true;
+
+    installPhase = ''
+      runHook preInstall
+      mkdir -p $out/opt/vllm-rocm
+      cp -r ./* $out/opt/vllm-rocm/
+      # Point lemonade's vllm.rocm_bin here. The bundle's own launcher sets the
+      # ROCm LD_LIBRARY_PATH; wrap it to also expose the interpreter's lib dir.
+      mkdir -p $out/bin
+      makeWrapper $out/opt/vllm-rocm/bin/vllm-server $out/bin/vllm-server \
+        --prefix LD_LIBRARY_PATH : "$out/opt/vllm-rocm/lib"
+      runHook postInstall
+    '';
+
+    # Bundled ELFs already have long internal runpaths; keep them.
+    dontStrip = true;
+
+    meta = {
+      description = "vLLM with ROCm backend for AMD Strix APUs (prebuilt, TheRock ROCm)";
+      homepage = "https://github.com/lemonade-sdk/vllm-rocm";
+      license = lib.licenses.asl20;
+      platforms = ["x86_64-linux"];
+      sourceProvenance = [lib.sourceTypes.binaryNativeCode];
+      mainProgram = "vllm-server";
+    };
+  }

--- a/pkgs/vllm-rocm/default.nix
+++ b/pkgs/vllm-rocm/default.nix
@@ -4,22 +4,23 @@
 # is far behind ROCm 7.15 and lacks the Strix gfx targets. Lemonade launches the
 # resulting `vllm-server` via the `vllm.rocm_bin` config override wired in the
 # NixOS module. See noamsto/nix-amd-ai#63.
+#
+# NOTE: deliberately NOT autoPatchelf'd. The bundle is self-contained — it ships
+# its own `rocm_sysdeps` (numa/drm/elf/lzma) and resolves its .so via internal
+# $ORIGIN runpaths. autoPatchelfHook rewrites those runpaths and injects nixpkgs
+# libs (gcc-15 libstdc++/libatomic) that mismatch the Ubuntu-built torch, which
+# segfaults on `import torch`. Instead we only repoint the ELF interpreter to the
+# nix loader and supply the two genuinely-missing system libs (libstdc++, libz)
+# via the launcher's LD_LIBRARY_PATH.
 {
   lib,
   stdenv,
   fetchurl,
-  autoPatchelfHook,
+  patchelf,
   makeWrapper,
+  bash,
+  coreutils,
   zlib,
-  zstd,
-  xz,
-  numactl,
-  libdrm,
-  ncurses,
-  elfutils,
-  openssl,
-  libxml2,
-  libGL,
   gpuTarget ? "gfx1150",
 }: let
   sources = import ./sources.nix;
@@ -27,6 +28,8 @@
     sources.${gpuTarget}
     or (throw "vllm-rocm: no prebuilt for gpuTarget '${gpuTarget}' (have: ${lib.concatStringsSep ", " (lib.attrNames sources)})");
   parts = map (p: fetchurl {inherit (p) url hash;}) src.parts;
+  # Ubuntu-built torch/ROCm want these from the system; the bundle omits them.
+  runtimeLibs = lib.makeLibraryPath [stdenv.cc.cc.lib zlib];
 in
   stdenv.mkDerivation {
     pname = "vllm-rocm";
@@ -35,27 +38,7 @@ in
     # Two <2 GB GitHub assets that concatenate into one .tar.gz.
     srcs = parts;
 
-    nativeBuildInputs = [autoPatchelfHook makeWrapper];
-
-    # External libs the bundled ELFs need; the ROCm/torch .so ship inside the
-    # bundle and resolve intra-tree once its own lib dirs are on the runpath.
-    buildInputs = [
-      zlib
-      zstd
-      xz
-      numactl
-      libdrm
-      ncurses
-      elfutils
-      openssl
-      libxml2
-      libGL
-      stdenv.cc.cc.lib
-    ];
-
-    # The bundle carries CUDA/other-vendor stubs it never dlopens on this path;
-    # don't fail the build over their absent deps.
-    autoPatchelfIgnoreMissingDeps = ["*"];
+    nativeBuildInputs = [patchelf makeWrapper];
 
     unpackPhase = ''
       runHook preUnpack
@@ -68,13 +51,50 @@ in
 
     installPhase = ''
       runHook preInstall
-      mkdir -p $out/opt/vllm-rocm
-      cp -r ./* $out/opt/vllm-rocm/
-      # Point lemonade's vllm.rocm_bin here. The bundle's own launcher sets the
-      # ROCm LD_LIBRARY_PATH; wrap it to also expose the interpreter's lib dir.
+      prefix=$out/opt/vllm-rocm
+      mkdir -p $prefix
+      cp -r ./* $prefix/
+
+      # Upstream tars the venv with no exec bits (everything is 0644), so the
+      # interpreter and launchers can't run. Restore +x on the bundled binaries.
+      # The bundled clang matters too: the launcher chmod +x's it at runtime,
+      # which silently no-ops on the read-only store, so pre-mark it here.
+      chmod -R u+x $prefix/bin
+      for d in $prefix/lib/python3.*/site-packages/_rocm_sdk_*/bin \
+               $prefix/lib/python3.*/site-packages/_rocm_sdk_*/lib/llvm/bin; do
+        [ -d "$d" ] && chmod -R u+x "$d"
+      done
+
+      # Repoint the ELF interpreter (FHS /lib64/ld-linux-x86-64.so.2 -> nix
+      # loader) on the executables the launcher actually execs — python3 and the
+      # bundled clang (Triton JIT). Leave every runpath intact.
+      loader=${stdenv.cc.bintools.dynamicLinker}
+      for exe in $prefix/bin/python3 $prefix/bin/python3.* \
+                 $prefix/lib/python3.*/site-packages/_rocm_sdk_*/lib/llvm/bin/clang; do
+        if [ -f "$exe" ] && patchelf --print-interpreter "$exe" >/dev/null 2>&1; then
+          patchelf --set-interpreter "$loader" "$exe"
+        fi
+      done
+
+      # Launcher shebang is #!/bin/bash (FHS); rewrite to the nix bash.
+      patchShebangs $prefix/bin/vllm-server
+
+      # The torch/numpy/scipy/... wheels are auditwheel-repaired: each native ext
+      # carries an $ORIGIN RUNPATH to a sibling *.libs dir. That $ORIGIN doesn't
+      # resolve reliably once relocated into the store, so surface every *.libs
+      # dir on LD_LIBRARY_PATH explicitly.
+      auditLibs=""
+      for d in $prefix/lib/python3.*/site-packages/*.libs; do
+        [ -d "$d" ] && auditLibs="$auditLibs:$d"
+      done
+
+      # lemonade's vllm.rocm_bin points at $out/bin/vllm-server. The launcher
+      # prepends the bundle's ROCm/torch lib dirs to LD_LIBRARY_PATH but relies
+      # on the system for libstdc++/libz; supply those and the coreutils it calls.
       mkdir -p $out/bin
-      makeWrapper $out/opt/vllm-rocm/bin/vllm-server $out/bin/vllm-server \
-        --prefix LD_LIBRARY_PATH : "$out/opt/vllm-rocm/lib"
+      makeWrapper $prefix/bin/vllm-server $out/bin/vllm-server \
+        --prefix PATH : ${lib.makeBinPath [bash coreutils]} \
+        --prefix LD_LIBRARY_PATH : "${runtimeLibs}$auditLibs"
       runHook postInstall
     '';
 

--- a/pkgs/vllm-rocm/sources.nix
+++ b/pkgs/vllm-rocm/sources.nix
@@ -9,11 +9,11 @@
     parts = [
       {
         url = "https://github.com/lemonade-sdk/vllm-rocm/releases/download/vllm0.23.1.dev0%2Brocm7.15.0a20260710.g0fc695fc6.d20260710-rocm7.15.0-gfx1150/vllm0.23.1.dev0%2Brocm7.15.0a20260710.g0fc695fc6.d20260710-rocm7.15.0-gfx1150-x64.part01-of-02.tar.gz";
-        hash = "sha256-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=";
+        hash = "sha256-aS8oZUecBTiod1lPoFpy9QfC+T9GXZnHeQc86zmdHbk=";
       }
       {
         url = "https://github.com/lemonade-sdk/vllm-rocm/releases/download/vllm0.23.1.dev0%2Brocm7.15.0a20260710.g0fc695fc6.d20260710-rocm7.15.0-gfx1150/vllm0.23.1.dev0%2Brocm7.15.0a20260710.g0fc695fc6.d20260710-rocm7.15.0-gfx1150-x64.part02-of-02.tar.gz";
-        hash = "sha256-BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB=";
+        hash = "sha256-tIXcYaMcpPOnVCx64id6+Lpiv9Qzsu5M09smYSDV2gM=";
       }
     ];
   };

--- a/pkgs/vllm-rocm/sources.nix
+++ b/pkgs/vllm-rocm/sources.nix
@@ -18,8 +18,21 @@
     ];
   };
 
-  # Strix Halo. The gfx1151 release exists upstream, but this flake hasn't
-  # pinned or validated it yet (no Halo host here) — pin the two part hashes
-  # and confirm inference before dropping this throw. See noamsto/nix-amd-ai#63.
-  gfx1151 = throw "vllm-rocm: the gfx1151 (Strix Halo) prebuilt is not yet pinned/validated — see noamsto/nix-amd-ai#63";
+  # Strix Halo. Hashes pinned; buildable, but not yet run on a Halo host — the
+  # gfx1150 recipe transfers, so this is expected to work. Validate inference on
+  # a gfx1151 machine before treating it as confirmed. See noamsto/nix-amd-ai#63.
+  gfx1151 = {
+    version = "0.23.1.dev0";
+    releaseTag = "vllm0.23.1.dev0+rocm7.15.0a20260710.g0fc695fc6.d20260710-rocm7.15.0-gfx1151";
+    parts = [
+      {
+        url = "https://github.com/lemonade-sdk/vllm-rocm/releases/download/vllm0.23.1.dev0%2Brocm7.15.0a20260710.g0fc695fc6.d20260710-rocm7.15.0-gfx1151/vllm0.23.1.dev0%2Brocm7.15.0a20260710.g0fc695fc6.d20260710-rocm7.15.0-gfx1151-x64.part01-of-02.tar.gz";
+        hash = "sha256-sFPe3SEB46FJWZ03ukzYfUeZQ+J/S52tDk1rrKKIh78=";
+      }
+      {
+        url = "https://github.com/lemonade-sdk/vllm-rocm/releases/download/vllm0.23.1.dev0%2Brocm7.15.0a20260710.g0fc695fc6.d20260710-rocm7.15.0-gfx1151/vllm0.23.1.dev0%2Brocm7.15.0a20260710.g0fc695fc6.d20260710-rocm7.15.0-gfx1151-x64.part02-of-02.tar.gz";
+        hash = "sha256-w/J1I0X1RZon+vBBkAIqQELEl1tphS6t+nBuCJ9W+2w=";
+      }
+    ];
+  };
 }

--- a/pkgs/vllm-rocm/sources.nix
+++ b/pkgs/vllm-rocm/sources.nix
@@ -1,0 +1,36 @@
+# Per-GPU-target prebuilt bundles from lemonade-sdk/vllm-rocm. Each release is a
+# relocatable Python 3.14 prefix bundling torch + vLLM + a full TheRock ROCm for
+# one gfx target, split across two <2 GB GitHub assets. Refresh with
+# scripts/bump-versions.sh (TODO: wire it in) or `nix store prefetch-file`.
+{
+  gfx1150 = {
+    version = "0.23.1.dev0";
+    releaseTag = "vllm0.23.1.dev0+rocm7.15.0a20260710.g0fc695fc6.d20260710-rocm7.15.0-gfx1150";
+    parts = [
+      {
+        url = "https://github.com/lemonade-sdk/vllm-rocm/releases/download/vllm0.23.1.dev0%2Brocm7.15.0a20260710.g0fc695fc6.d20260710-rocm7.15.0-gfx1150/vllm0.23.1.dev0%2Brocm7.15.0a20260710.g0fc695fc6.d20260710-rocm7.15.0-gfx1150-x64.part01-of-02.tar.gz";
+        hash = "sha256-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=";
+      }
+      {
+        url = "https://github.com/lemonade-sdk/vllm-rocm/releases/download/vllm0.23.1.dev0%2Brocm7.15.0a20260710.g0fc695fc6.d20260710-rocm7.15.0-gfx1150/vllm0.23.1.dev0%2Brocm7.15.0a20260710.g0fc695fc6.d20260710-rocm7.15.0-gfx1150-x64.part02-of-02.tar.gz";
+        hash = "sha256-BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB=";
+      }
+    ];
+  };
+
+  # Strix Halo (incoming host). Fill hashes when validated on gfx1151.
+  gfx1151 = {
+    version = "0.23.1.dev0";
+    releaseTag = "vllm0.23.1.dev0+rocm7.15.0a20260710.g0fc695fc6.d20260710-rocm7.15.0-gfx1151";
+    parts = [
+      {
+        url = "https://github.com/lemonade-sdk/vllm-rocm/releases/download/vllm0.23.1.dev0%2Brocm7.15.0a20260710.g0fc695fc6.d20260710-rocm7.15.0-gfx1151/vllm0.23.1.dev0%2Brocm7.15.0a20260710.g0fc695fc6.d20260710-rocm7.15.0-gfx1151-x64.part01-of-02.tar.gz";
+        hash = "sha256-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=";
+      }
+      {
+        url = "https://github.com/lemonade-sdk/vllm-rocm/releases/download/vllm0.23.1.dev0%2Brocm7.15.0a20260710.g0fc695fc6.d20260710-rocm7.15.0-gfx1151/vllm0.23.1.dev0%2Brocm7.15.0a20260710.g0fc695fc6.d20260710-rocm7.15.0-gfx1151-x64.part02-of-02.tar.gz";
+        hash = "sha256-BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB=";
+      }
+    ];
+  };
+}

--- a/pkgs/vllm-rocm/sources.nix
+++ b/pkgs/vllm-rocm/sources.nix
@@ -18,19 +18,8 @@
     ];
   };
 
-  # Strix Halo (incoming host). Fill hashes when validated on gfx1151.
-  gfx1151 = {
-    version = "0.23.1.dev0";
-    releaseTag = "vllm0.23.1.dev0+rocm7.15.0a20260710.g0fc695fc6.d20260710-rocm7.15.0-gfx1151";
-    parts = [
-      {
-        url = "https://github.com/lemonade-sdk/vllm-rocm/releases/download/vllm0.23.1.dev0%2Brocm7.15.0a20260710.g0fc695fc6.d20260710-rocm7.15.0-gfx1151/vllm0.23.1.dev0%2Brocm7.15.0a20260710.g0fc695fc6.d20260710-rocm7.15.0-gfx1151-x64.part01-of-02.tar.gz";
-        hash = "sha256-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=";
-      }
-      {
-        url = "https://github.com/lemonade-sdk/vllm-rocm/releases/download/vllm0.23.1.dev0%2Brocm7.15.0a20260710.g0fc695fc6.d20260710-rocm7.15.0-gfx1151/vllm0.23.1.dev0%2Brocm7.15.0a20260710.g0fc695fc6.d20260710-rocm7.15.0-gfx1151-x64.part02-of-02.tar.gz";
-        hash = "sha256-BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB=";
-      }
-    ];
-  };
+  # Strix Halo. The gfx1151 release exists upstream, but this flake hasn't
+  # pinned or validated it yet (no Halo host here) — pin the two part hashes
+  # and confirm inference before dropping this throw. See noamsto/nix-amd-ai#63.
+  gfx1151 = throw "vllm-rocm: the gfx1151 (Strix Halo) prebuilt is not yet pinned/validated — see noamsto/nix-amd-ai#63";
 }


### PR DESCRIPTION
Refs #63. **Draft / WIP PoC** — packaging works end-to-end on NixOS and generates tokens on the GPU (gfx1150); still WIP for lemonade integration + gfx1151.

## Approach

Building vLLM + ROCm from source is blocked (nixpkgs `rocmPackages` is far behind ROCm 7.15 and lacks the Strix gfx targets), so this **repackages the upstream `lemonade-sdk/vllm-rocm` prebuilt** — a relocatable Python 3.14 prefix bundling torch + vLLM + a full TheRock ROCm for one gfx target, split across two <2 GB GitHub assets.

Lemonade already supports vLLM natively and resolves the backend via a `vllm.rocm_bin` config override, so no upstream patching of the launch path is needed — just point it at a nix-provided `vllm-server`.

## What works (validated on a gfx1150 / Strix Point host)

- `nix build .#vllm-rocm` succeeds (7.6 GB closure)
- `$out/bin/vllm-server --help` runs in a clean `env -i` (exit 0), printing the OpenAI API server usage with the `--model` / `--port` / `--max-model-len` args lemonade drives
- `import torch` → `2.11.0+rocm7.15.0` (`hip 7.15.0`); `import vllm` → `0.23.1.dev0`
- Module wiring behind `enableVllm` / `vllmGpuTarget`: `/etc/lemonade/backends/vllm-rocm` symlink + `vllm.rocm_bin` defaults seed + an `enableVllm requires enableROCm && enableLemonade` assertion

## The load-bearing packaging note

Do **not** `autoPatchelfHook` this bundle — it is self-contained (ships its own `rocm_sysdeps`, resolves `.so` via internal `$ORIGIN` runpaths). autoPatchelf rewrites those runpaths and injects nixpkgs gcc-15 `libstdc++`/`libatomic` over the Ubuntu-built torch, which **segfaults on `import torch`** (same class as #57). The working method is interpreter-only: set the nix ELF loader on `python3`/`clang`, keep every runpath, and supply the genuinely-missing system libs (`libstdc++`, `libz`) + the auditwheel `*.libs` dirs via the wrapper `LD_LIBRARY_PATH`.

## Not done yet (why this is a draft)

- [x] **Live GPU inference (standalone)** — validated on gfx1150: real tokens generated through ROCM_ATTN, 9.23 GiB GPU KV cache (see comment below). Still TODO: drive it *through lemonade*.
- [~] **gfx1151 (Strix Halo)** — hashes pinned + evaluates/builds; runtime validation pending a real Halo host
- [x] **README + CI** — enableVllm documented; module-eval-vllm check added
- [ ] Version-bump automation for the nightly-dated per-gfx tags (follow-up)


https://claude.ai/code/session_01Jxd7dRGeQvKTfd1cPEgG6j



