### PR TITLE
ci(vllm): auto-update vllm-rocm in the weekly bump workflow

### DIFF
--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -23,6 +23,11 @@ jobs:
         with:
           name: nix-amd-ai
           authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
+          # vllm-rocm is a ~7.6 GB blob that turns over every few nightlies — one
+          # build alone exceeds the 5 GB free tier, so it's built to *validate*
+          # the bump but kept out of the cache push. Drop this filter once a paid
+          # cachix plan has headroom, to serve it prebuilt to consumers.
+          pushFilter: '(vllm)'
 
       - name: Check for new releases
         id: check
@@ -42,7 +47,15 @@ jobs:
           ./scripts/bump-versions.sh \
             "${{ steps.check.outputs.flm_latest }}" "${{ steps.check.outputs.flm_current }}" \
             "${{ steps.check.outputs.lem_latest }}" "${{ steps.check.outputs.lem_current }}" \
-            "${{ steps.check.outputs.xdna_latest }}" "${{ steps.check.outputs.xdna_current }}"
+            "${{ steps.check.outputs.xdna_latest }}" "${{ steps.check.outputs.xdna_current }}" \
+            "${{ steps.check.outputs.vllm_latest }}" "${{ steps.check.outputs.vllm_current }}"
+
+      # vllm-rocm builds unpack ~7.6 GB; the runner's ~14 GB default isn't enough.
+      # Reclaim the preinstalled Android/.NET/GHC toolchains (~25 GB) so the
+      # validation build below fits. Only when vllm actually moved.
+      - name: Free disk space for vllm-rocm build
+        if: steps.check.outputs.vllm_needs_update == 'true'
+        uses: jlumbroso/free-disk-space@main
 
       - name: Validate flake eval
         if: steps.check.outputs.needs_update == 'true'
@@ -65,7 +78,14 @@ jobs:
         id: build
         run: |
           FAILED=""
-          for pkg in xrt xrt-plugin-amdxdna fastflowlm lemonade; do
+          PKGS="xrt xrt-plugin-amdxdna fastflowlm lemonade"
+          # Validate the vllm-rocm bump only when it moved — building it (and
+          # re-fetching 2.25 GB) every run when unchanged is pure waste since it
+          # isn't in the cache. A build failure here blocks the auto-merge below.
+          if [ "${{ steps.check.outputs.vllm_needs_update }}" = "true" ]; then
+            PKGS="$PKGS vllm-rocm"
+          fi
+          for pkg in $PKGS; do
             if ! nix build ".#$pkg"; then
               FAILED+="- ${pkg}"$'\n'
             fi
@@ -101,6 +121,9 @@ jobs:
             BODY+="- Lemonade: ${{ steps.check.outputs.lem_current }} -> ${{ steps.check.outputs.lem_latest }}"$'\n'
           [ "${{ steps.check.outputs.xdna_latest }}" != "${{ steps.check.outputs.xdna_current }}" ] && \
             BODY+="- xdna-driver: ${{ steps.check.outputs.xdna_current }} -> ${{ steps.check.outputs.xdna_latest }}"$'\n'
+          if [ "${{ steps.check.outputs.vllm_needs_update }}" = "true" ]; then
+            BODY+="- vLLM-ROCm: \`${{ steps.check.outputs.vllm_current }}\` -> \`${{ steps.check.outputs.vllm_latest }}\` (built to validate; not GPU-tested)"$'\n'
+          fi
 
           NIXPKGS_DIFFS='${{ steps.check.outputs.nixpkgs_backend_diffs }}'
           if [ -n "$NIXPKGS_DIFFS" ]; then

--- a/pkgs/vllm-rocm/sources.nix
+++ b/pkgs/vllm-rocm/sources.nix
@@ -1,7 +1,7 @@
 # Per-GPU-target prebuilt bundles from lemonade-sdk/vllm-rocm. Each release is a
 # relocatable Python 3.14 prefix bundling torch + vLLM + a full TheRock ROCm for
-# one gfx target, split across two <2 GB GitHub assets. Refresh with
-# scripts/bump-versions.sh (TODO: wire it in) or `nix store prefetch-file`.
+# one gfx target, split across two <2 GB GitHub assets. Auto-bumped by the
+# weekly update workflow (scripts/check-updates.sh + bump-versions.sh).
 {
   gfx1150 = {
     version = "0.23.1.dev0";

--- a/scripts/bump-versions.sh
+++ b/scripts/bump-versions.sh
@@ -1,11 +1,13 @@
 #!/usr/bin/env bash
 # Bump package versions in derivation files.
-# Usage: bump-versions.sh <flm_new> <flm_old> <lem_new> <lem_old> <xdna_new> <xdna_old>
+# Usage: bump-versions.sh <flm_new> <flm_old> <lem_new> <lem_old> <xdna_new> <xdna_old> [vllm_new] [vllm_old]
+# vllm_new/old are the gfx-stripped base release tags (see check-updates.sh).
 set -euo pipefail
 
 FLM_NEW="$1" FLM_OLD="$2"
 LEM_NEW="$3" LEM_OLD="$4"
 XDNA_NEW="$5" XDNA_OLD="$6"
+VLLM_NEW="${7:-}" VLLM_OLD="${8:-}"
 
 update_hash() {
   local pkg="$1"
@@ -71,6 +73,39 @@ if [ "$XDNA_NEW" != "$XDNA_OLD" ]; then
   fi
 
   update_hash xrt-plugin-amdxdna
+fi
+
+# vLLM-ROCm — prebuilt per-gfx split bundles. The base tag (minus -gfxNNNN)
+# appears plain in each releaseTag and URL-encoded (+ -> %2B) in each URL, so
+# swap both, then blank and refill the four hashes in file order (gfx1150 p1/p2,
+# gfx1151 p1/p2) via direct prefetch — nix build can't emit per-part hashes.
+if [ -n "$VLLM_NEW" ] && [ "$VLLM_NEW" != "$VLLM_OLD" ]; then
+  echo "Bumping vLLM-ROCm: $VLLM_OLD -> $VLLM_NEW"
+  src=pkgs/vllm-rocm/sources.nix
+  old_enc="${VLLM_OLD//+/%2B}"
+  new_enc="${VLLM_NEW//+/%2B}"
+  old_ver="${VLLM_OLD#vllm}"; old_ver="${old_ver%%+*}"
+  new_ver="${VLLM_NEW#vllm}"; new_ver="${new_ver%%+*}"
+
+  sed -i "s|$old_enc|$new_enc|g; s|$VLLM_OLD|$VLLM_NEW|g" "$src"
+  [ "$old_ver" != "$new_ver" ] && sed -i "s/version = \"$old_ver\"/version = \"$new_ver\"/g" "$src"
+  sed -i 's/hash = "sha256-[^"]*"/hash = ""/' "$src"
+
+  base_url="https://github.com/lemonade-sdk/vllm-rocm/releases/download"
+  for target in gfx1150 gfx1151; do
+    enctag="${new_enc}-${target}"
+    for part in part01-of-02 part02-of-02; do
+      url="${base_url}/${enctag}/${enctag}-x64.${part}.tar.gz"
+      echo "  Prefetching $target $part..."
+      h=$(nix store prefetch-file --json "$url" | jq -r .hash || true)
+      if [ -n "$h" ]; then
+        sed -i "0,/hash = \"\"/s||hash = \"$h\"|" "$src"
+        echo "    $h"
+      else
+        echo "  WARNING: could not prefetch $target $part"
+      fi
+    done
+  done
 fi
 
 echo "Version bump complete."

--- a/scripts/check-updates.sh
+++ b/scripts/check-updates.sh
@@ -6,19 +6,27 @@ set -euo pipefail
 FLM_LATEST=$(gh api repos/FastFlowLM/FastFlowLM/releases/latest --jq '.tag_name' | sed 's/^v//')
 LEM_LATEST=$(gh api repos/lemonade-sdk/lemonade/releases/latest --jq '.tag_name' | sed 's/^v//')
 XDNA_LATEST=$(gh api "repos/amd/xdna-driver/commits?sha=1.7&per_page=1" --jq '.[0].sha')
+# vLLM-ROCm cuts one dated nightly per gfx target; strip the -gfxNNNN suffix to
+# get the shared base tag every target pins to.
+VLLM_LATEST=$(gh api repos/lemonade-sdk/vllm-rocm/releases/latest --jq '.tag_name' | sed 's/-gfx[^-]*$//')
 
 FLM_CURRENT=$(grep 'version = ' pkgs/fastflowlm/default.nix | head -1 | sed 's/.*"\(.*\)".*/\1/')
 LEM_CURRENT=$(sed -n 's/.*"\(.*\)".*/\1/p' pkgs/lemonade/version.nix | head -1)
 XDNA_CURRENT=$(grep 'rev = ' pkgs/xrt-plugin-amdxdna/default.nix | head -1 | sed 's/.*"\(.*\)".*/\1/')
+VLLM_CURRENT=$(grep 'releaseTag = ' pkgs/vllm-rocm/sources.nix | head -1 | sed 's/.*"\(.*\)".*/\1/; s/-gfx[^-]*$//')
 
 NEEDS_UPDATE=false
 [ "$FLM_LATEST" != "$FLM_CURRENT" ] && NEEDS_UPDATE=true
 [ "$LEM_LATEST" != "$LEM_CURRENT" ] && NEEDS_UPDATE=true
 [ "$XDNA_LATEST" != "$XDNA_CURRENT" ] && NEEDS_UPDATE=true
+VLLM_NEEDS_UPDATE=false
+[ "$VLLM_LATEST" != "$VLLM_CURRENT" ] && VLLM_NEEDS_UPDATE=true
+[ "$VLLM_LATEST" != "$VLLM_CURRENT" ] && NEEDS_UPDATE=true
 
 echo "FLM: $FLM_CURRENT -> $FLM_LATEST"
 echo "Lemonade: $LEM_CURRENT -> $LEM_LATEST"
 echo "XDNA: $XDNA_CURRENT -> $XDNA_LATEST"
+echo "vLLM-ROCm: $VLLM_CURRENT -> $VLLM_LATEST"
 
 # nixpkgs lock vs nixos-unstable HEAD. We surface diffs for the six backend
 # packages we consume (Lemonade pins their versions into backend_versions.json
@@ -72,10 +80,13 @@ if [ -n "${GITHUB_OUTPUT:-}" ]; then
     echo "flm_latest=$FLM_LATEST"
     echo "lem_latest=$LEM_LATEST"
     echo "xdna_latest=$XDNA_LATEST"
+    echo "vllm_latest=$VLLM_LATEST"
     echo "flm_current=$FLM_CURRENT"
     echo "lem_current=$LEM_CURRENT"
     echo "xdna_current=$XDNA_CURRENT"
+    echo "vllm_current=$VLLM_CURRENT"
     echo "needs_update=$NEEDS_UPDATE"
+    echo "vllm_needs_update=$VLLM_NEEDS_UPDATE"
     echo "nixpkgs_needs_update=$NIXPKGS_NEEDS_UPDATE"
     echo "mtp_cleanup=$MTP_CLEANUP"
     echo "mtp_override_needs_update=$MTP_OVERRIDE_NEEDS_UPDATE"


### PR DESCRIPTION
Wires `vllm-rocm` into the weekly update automation (follow-up to #63/#65).

## What it does

- **`check-updates.sh`** detects the latest `lemonade-sdk/vllm-rocm` release, comparing the gfx-stripped **base tag** (all four gfx variants share one) against the pinned one.
- **`bump-versions.sh`** rewrites `pkgs/vllm-rocm/sources.nix` — swaps the base tag (plain in `releaseTag`, URL-encoded `+`→`%2B` in URLs), bumps the version, and refills the four per-gfx part hashes via direct `nix store prefetch-file`.
- **`update.yml`** reclaims ~25 GB of runner disk (`free-disk-space`) and builds `vllm-rocm` to **validate** the bump — a build failure blocks the existing auto-merge gate, so only a clean bump lands automatically.

## Two decisions baked in

- **Validate → auto-merge.** The bundle now builds in CI (with disk reclaim), so a successful build gates auto-merge like the other four packages. It validates structure (unpack + patchelf + wrapper), not GPU inference — noted in the generated PR body.
- **Not cached (yet).** One build (~7.6 GB) exceeds the 5 GB cachix free tier, so it is kept out of the push via `pushFilter: (vllm)`. Drop that filter once a paid plan has headroom to serve it prebuilt; consumers otherwise build locally.

## Validation

- `shellcheck` + `actionlint` clean.
- Bump sed-transform tested on a copy: base tag fully swapped, 4 encoded URLs, hashes refilled in file order, version + gfx-suffixes preserved.
- `check-updates.sh` run live: current == latest (upstream paused at 2026-07-10) → **no false bump**.

Only fires when a new release appears, so no per-run cost while upstream is idle.

https://claude.ai/code/session_01Jxd7dRGeQvKTfd1cPEgG6j