### PR TITLE
feat(module): add lemonade.settings and reconcile module-managed config on start

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,10 +185,49 @@ Vanilla v10.5.0 ignores these env vars on NixOS for several reasons that this fl
 - The Linux ROCm `LD_LIBRARY_PATH` block is gated on the same check, so a nix-store `llama-server` keeps its RPATH-resolved libs instead of being shadowed by `~/.cache/lemonade/bin/.../lib`.
 - `is_ggml_hip_plugin_available()` honors `LEMONADE_GGML_HIP_PATH` so the `system` llamacpp recipe stops being permanently `unsupported` on NixOS.
 - `LEMONADE_WHISPERCPP_VULKAN_BIN` is added to the env-var migration table (upstream only mapped CPU/NPU for whispercpp).
-- `ConfigFile::load` re-applies the env overlay on every startup, not just first run, so bumping `pkgs.*` propagates without users having to delete `~/.cache/lemonade/config.json`.
+- `ConfigFile::get_defaults` honors `LEMONADE_DEFAULTS_PATH`, so the module can seed backend bin paths from a store path instead of the hardcoded `/usr/share/lemonade/defaults.json` that NixOS can't populate (v10.7.0 dropped the env→config migration this replaced).
 - The download SSE handler treats `sink.write` failure as a transient client disconnect rather than a cancel signal, so a backgrounded Tauri window doesn't kill an in-flight multi-GB download.
 
 If `lemonade backends` reports a backend as `installed` but benchmarks report <5 t/s decode on a small model, you're on CPU — check that the matching `enable*` option is set and the host has been rebuilt.
+
+### Runtime config: `lemonade.settings`
+
+`LEMONADE_DEFAULTS_PATH` only seeds `~/.cache/lemonade/config.json` on lemond's
+**first** run — afterwards `ConfigFile::load` merges the packaged defaults
+*under* the persisted file, so every key the module declares goes inert. Backend
+bin paths survived that because they point at stable `/etc/lemonade/backends/*`
+symlinks, but scalars did not: a host that first started lemond before enabling
+`enableVllm` kept `global_timeout = 0`, which vLLM reads as its startup-readiness
+budget and turns into zero poll attempts ([#68](https://github.com/noamsto/nix-amd-ai/issues/68)).
+
+The lemond unit therefore re-applies the module-declared keys on every start,
+leaving everything else to whatever the web UI persisted. `lemonade.settings`
+rides the same path for keys the module has no dedicated option for:
+
+```nix
+hardware.amd-npu.lemonade.settings = {
+  max_loaded_models = -1;   # keep a small NPU model and a big GPU model resident together
+  auto_evict = true;        # then let lemond reclaim on idle / VRAM pressure
+};
+```
+
+`max_loaded_models` (default `1`) is what makes models take turns — raise or
+unset it (`-1`) to keep several resident. `auto_evict` is a *separate*,
+opt-in background reclaimer (default **off**) that unloads idle models and
+sheds them once VRAM crosses `auto_evict_threshold_pct` (default `0.90`); it
+pairs naturally with an unlimited `max_loaded_models`. Anything lemond's
+`RuntimeConfig` validates is accepted. Values merge recursively over the
+module's computed defaults, so overriding `llamacpp.args` does not drop the
+sibling `llamacpp.*_bin` paths.
+
+Per-*model* eviction knobs (`pinned`, `evict_idle_timeout`,
+`downsize_idle_timeout`, `evict_weight_factor`, and a per-recipe `auto_evict`
+override) live in lemond's separate `recipe_options.json` and are set through
+lemonade itself, not through this option.
+
+Reconciliation only ever writes keys, never deletes them: dropping a key from
+`settings` stops it being re-applied but leaves the last value in the persisted
+config. Set it back to the value you want rather than removing the line.
 
 ### Tauri desktop app: download progress is fragile when backgrounded
 

--- a/flake.nix
+++ b/flake.nix
@@ -368,7 +368,23 @@
                 jq -e '.max_loaded_models == -1' "$defaults" >/dev/null
                 jq -e '.llamacpp.args == "--custom"' "$defaults" >/dev/null
                 jq -e '.llamacpp.cpu_bin | startswith("/etc/lemonade/backends/")' "$defaults" >/dev/null
-                grep -q 'ExecStartPre=.*lemond-reconcile-config' "$unit"/lemond.service
+
+                # Run the unit's own ExecStartPre against a config that has both a
+                # stale module-managed key and a user-only key, and assert the merge
+                # direction — a broken jq expression would otherwise ship green.
+                reconcile=$(sed -n 's/^ExecStartPre=//p' "$unit"/lemond.service)
+                export HOME=$TMPDIR/home
+                mkdir -p "$HOME/.cache/lemonade"
+                cfg=$HOME/.cache/lemonade/config.json
+                echo '{"host":"0.0.0.0","max_loaded_models":1,"llamacpp":{"args":"--stale"}}' >"$cfg"
+                chmod 600 "$cfg"
+                "$reconcile"
+
+                jq -e '.max_loaded_models == -1' "$cfg" >/dev/null   # module key re-applied
+                jq -e '.llamacpp.args == "--custom"' "$cfg" >/dev/null
+                jq -e '.host == "0.0.0.0"' "$cfg" >/dev/null         # user-only key preserved
+                [ "$(stat -c %a "$cfg")" = 600 ]                     # mode not widened
+
                 touch $out
               '';
 

--- a/flake.nix
+++ b/flake.nix
@@ -325,6 +325,53 @@
                 ];
               }).config.systemd.services.lemond.environment.LEMONADE_DEFAULTS_PATH;
 
+            # lemonade.settings must deep-merge over the module's computed
+            # defaults — overriding one key without dropping its siblings — and
+            # the unit must re-apply them on every start, else the option is
+            # inert on any host that already persisted a config.json.
+            module-eval-lemonade-settings = let
+              sys =
+                (inputs.nixpkgs.lib.nixosSystem {
+                  inherit system;
+                  modules = [
+                    inputs.self.nixosModules.default
+                    {
+                      boot.loader.grub.enable = false;
+                      fileSystems."/" = {
+                        device = "/dev/sda1";
+                        fsType = "ext4";
+                      };
+                      hardware.amd-npu = {
+                        enable = true;
+                        enableLemonade = true;
+                        lemonade = {
+                          user = "testuser";
+                          settings = {
+                            max_loaded_models = -1;
+                            llamacpp.args = "--custom";
+                          };
+                        };
+                      };
+                      users.users.testuser = {
+                        isNormalUser = true;
+                        extraGroups = ["video" "render"];
+                      };
+                    }
+                  ];
+                }).config;
+            in
+              pkgs.runCommand "module-eval-lemonade-settings" {
+                nativeBuildInputs = [pkgs.jq];
+                defaults = sys.systemd.services.lemond.environment.LEMONADE_DEFAULTS_PATH;
+                unit = sys.systemd.units."lemond.service".unit;
+              } ''
+                jq -e '.max_loaded_models == -1' "$defaults" >/dev/null
+                jq -e '.llamacpp.args == "--custom"' "$defaults" >/dev/null
+                jq -e '.llamacpp.cpu_bin | startswith("/etc/lemonade/backends/")' "$defaults" >/dev/null
+                grep -q 'ExecStartPre=.*lemond-reconcile-config' "$unit"/lemond.service
+                touch $out
+              '';
+
             # GTT headroom: configured system emits the ttm modprobe line with
             # GiB→page conversion; default system emits no ttm line.
             module-eval-gtt = let

--- a/modules/amd-npu.nix
+++ b/modules/amd-npu.nix
@@ -114,7 +114,29 @@
     // optionalAttrs (cfg.enableROCm && cfg.enableVllm) {
       vllm.rocm_bin = lemonadeBackendBin "vllm-rocm";
     };
-  lemonadeDefaultsFile = (pkgs.formats.json {}).generate "lemonade-defaults.json" lemonadeDefaults;
+  lemonadeDefaultsFile =
+    (pkgs.formats.json {}).generate "lemonade-defaults.json"
+    (lib.recursiveUpdate lemonadeDefaults cfg.lemonade.settings);
+
+  # LEMONADE_DEFAULTS_PATH only seeds config.json on lemond's first run — after
+  # that the persisted file wins for every key it holds, so module-declared
+  # values rot. Re-apply ours each start. See noamsto/nix-amd-ai#67 and #68.
+  lemonadeReconcile = pkgs.writeShellApplication {
+    name = "lemond-reconcile-config";
+    runtimeInputs = [pkgs.jq];
+    text = ''
+      config="''${LEMONADE_CACHE_DIR:-$HOME/.cache/lemonade}/config.json"
+      [ -f "$config" ] || exit 0
+
+      tmp="$config.nix-reconcile"
+      if jq -s '.[0] * .[1]' "$config" ${lemonadeDefaultsFile} >"$tmp"; then
+        mv "$tmp" "$config"
+      else
+        rm -f "$tmp"
+        echo "lemond: $config is unreadable, leaving it untouched" >&2
+      fi
+    '';
+  };
 in {
   options.hardware.amd-npu = {
     enable = mkEnableOption "AMD NPU (AI Engine) support";
@@ -225,6 +247,29 @@ in {
           because upstream lemonade doesn't enable FA for llama-cpp despite enabling it
           for vLLM (see vllm_server.cpp:202); measured ~5% decode / ~10% prefill gain on
           gfx1150 + Gemma. Set "auto" or "off" to override.
+        '';
+      };
+
+      settings = mkOption {
+        type = (pkgs.formats.json {}).type;
+        default = {};
+        example = lib.literalExpression ''
+          {
+            max_loaded_models = -1;
+            auto_evict = true;
+          }
+        '';
+        description = ''
+          Extra keys merged into lemond's runtime config, overriding the values
+          this module computes. Accepts anything `RuntimeConfig` validates —
+          e.g. `max_loaded_models` (-1 for unlimited, so a small NPU model and a
+          large GPU model can stay resident together instead of taking turns),
+          and `auto_evict` (opt-in idle/VRAM-pressure eviction, off by default)
+          with its `auto_evict_threshold_pct`.
+
+          These keys are re-applied on every `lemond` start, so they stay
+          declarative; keys not listed here are left to whatever the web UI
+          persisted in `''${LEMONADE_CACHE_DIR:-~/.cache/lemonade}/config.json`.
         '';
       };
     };
@@ -476,6 +521,7 @@ in {
       serviceConfig = {
         Type = "simple";
         User = cfg.lemonade.user;
+        ExecStartPre = "${lemonadeReconcile}/bin/lemond-reconcile-config";
         ExecStart = "${lemonadePackage}/bin/lemond --port ${toString cfg.lemonade.port} --host ${cfg.lemonade.host}";
         Restart = "on-failure";
         RestartSec = "5s";

--- a/modules/amd-npu.nix
+++ b/modules/amd-npu.nix
@@ -123,13 +123,15 @@
   # values rot. Re-apply ours each start. See noamsto/nix-amd-ai#67 and #68.
   lemonadeReconcile = pkgs.writeShellApplication {
     name = "lemond-reconcile-config";
-    runtimeInputs = [pkgs.jq];
+    runtimeInputs = [pkgs.jq pkgs.coreutils];
     text = ''
-      config="''${LEMONADE_CACHE_DIR:-$HOME/.cache/lemonade}/config.json"
+      config="''${LEMONADE_CACHE_DIR:-''${HOME:-}/.cache/lemonade}/config.json"
       [ -f "$config" ] || exit 0
 
       tmp="$config.nix-reconcile"
       if jq -s '.[0] * .[1]' "$config" ${lemonadeDefaultsFile} >"$tmp"; then
+        # lemond may have tightened the mode; rename would silently widen it back.
+        chmod --reference="$config" "$tmp"
         mv "$tmp" "$config"
       else
         rm -f "$tmp"


### PR DESCRIPTION
Closes #67. Fixes the immediate blocker in #68.

## Problem

`LEMONADE_DEFAULTS_PATH` only seeds `~/.cache/lemonade/config.json` on lemond's **first** run. After that `ConfigFile::load` merges the packaged defaults *under* the persisted file:

```cpp
// Deep-merge: user values override defaults, missing fields filled from defaults.
json merged = utils::JsonUtils::merge(defaults, loaded);   // config_file.cpp:128
```

So every key the module declares goes inert on any host that has started lemond before. Backend bin paths escaped this because they point at stable `/etc/lemonade/backends/*` symlinks; scalars did not.

That is why enabling `enableVllm` on an existing host leaves `global_timeout` at 0. vLLM reads it as its startup-readiness budget (`vllm_server.cpp:507`), and `wait_for_ready` turns 0 into zero poll attempts, so `vllm-server` reports "failed to start within timeout" in the same millisecond it starts — #68.

Separately, the module had no way to set lemond runtime config at all: `lemonade` exposed only `port`, `host`, `user`, `flashAttn` and `desktopApp.enable`, so upstream's `max_loaded_models` / `auto_evict` / `auto_evict_threshold_pct` were unreachable — #67.

## Change

- **`ExecStartPre`** on the lemond unit deep-merges the generated defaults over the persisted config on every start, so module-declared keys stay declarative and web-UI keys outside that set are preserved.
- **`lemonade.settings`** — freeform JSON, `recursiveUpdate`'d over the computed defaults, for keys with no dedicated option.

Missing config exits 0; corrupt config is left untouched and also exits 0, so `ExecStartPre` can never block lemond from starting. (Without that guard `set -e` would turn a config lemond recovers from on its own into a boot failure.)

## Verification

`nix flake check` — all 9 green, including the new `module-eval-lemonade-settings`, which asserts settings land, an override does *not* drop its siblings, and the unit carries the `ExecStartPre`.

The built script run against a simulated pre-vLLM config:

| key | before | after |
|---|---|---|
| `global_timeout` | `0` | `3600` |
| `vllm.rocm_bin` | *absent* | `/etc/lemonade/backends/vllm-rocm` |
| `flm.prefer_system` | *absent* | `true` |
| `host` (user-set) | `0.0.0.0` | `0.0.0.0` |
| `log_level` (user-set) | `debug` | `debug` |

## Notes for review

- `global_timeout = 0` (the non-vLLM branch, `amd-npu.nix:87`) is a value lemonade's own validator rejects — `runtime_config.cpp:551` throws `'global_timeout' must be positive`. It only survives because the load path doesn't validate. Left as-is since it's the documented workaround for lemonade-sdk/lemonade#1364, but reconcile now writes it on every start where before it only landed on first run.
- Reconciliation writes keys, never deletes them — dropping a key from `settings` leaves the last value persisted. Documented rather than solved; propagating removals needs cross-generation state.
- A stale README bullet claimed `ConfigFile::load` re-applies the overlay on every startup. That patch died with the v10.7.0 env→config removal, and the false claim was masking this bug. Corrected.