### PR TITLE
test(module): boot lemond in a VM to cover the reconcile hook

### DIFF
--- a/README.md
+++ b/README.md
@@ -229,6 +229,14 @@ Reconciliation only ever writes keys, never deletes them: dropping a key from
 `settings` stops it being re-applied but leaves the last value in the persisted
 config. Set it back to the value you want rather than removing the line.
 
+Two keys are *not* reachable this way. `lemond` persists `--port` and `--host`
+into `config.json` itself on every start, after the reconcile hook has run, so
+`settings.host` / `settings.port` are silently overwritten — use the dedicated
+`lemonade.host` and `lemonade.port` options instead. That same write also
+rewrites the file through a fresh `ofstream` + rename, which resets its mode to
+`0644` on every start; the hook preserves whatever mode it finds, but it cannot
+hold the file tighter than lemond leaves it.
+
 ### Tauri desktop app: download progress is fragile when backgrounded
 
 WebKitGTK suspends the network process for windows that are minimized, hidden, or moved to another workspace. That kills the SSE progress stream lemond uses for downloads at ~60–90 s. Without our patch, that nuked the whole download mid-flight. With the patch, the download keeps running server-side and finishes regardless — but the UI stops seeing progress until you refocus the window (and may need a refresh to pick up the result). For very large pulls, prefer the regular browser at `http://localhost:13305` or `lemonade pull <model>` from the CLI; both survive backgrounding cleanly.

--- a/flake.nix
+++ b/flake.nix
@@ -388,6 +388,80 @@
                 touch $out
               '';
 
+            # The checks above prove the unit renders and that the hook behaves
+            # when invoked by hand. This one boots it: lemond must actually reach
+            # active with the ExecStartPre in front of it. That is the failure
+            # class eval checks structurally cannot see — a hook that aborts
+            # takes the whole service down with it.
+            lemond-vm =
+              # Driven from an already-overlaid pkgs, importing the bare module:
+              # nixosModules.default bundles nixpkgs.overlays for consumers, and
+              # the test framework pins nixpkgs read-only.
+              (import inputs.nixpkgs {
+                inherit system;
+                overlays = [inputs.self.overlays.default];
+              })
+            .testers.runNixOSTest {
+                name = "lemond-reconcile";
+                nodes.machine = {
+                  lib,
+                  pkgs,
+                  ...
+                }: {
+                  imports = [./modules/amd-npu.nix];
+                  environment.systemPackages = [pkgs.jq];
+                  hardware.amd-npu = {
+                    enable = true;
+                    enableNPU = false;
+                    enableFastFlowLM = false;
+                    enableROCm = false;
+                    enableVulkan = false;
+                    enableImageGen = false;
+                    lemonade = {
+                      user = "tester";
+                      settings.max_loaded_models = -1;
+                    };
+                  };
+                  users.users.tester.isNormalUser = true;
+                  # Hold lemond back so the stale config is in place before its
+                  # first start; left to boot it would seed a fresh config, the one
+                  # path that never exercises reconciliation.
+                  systemd.services.lemond.wantedBy = lib.mkForce [];
+                };
+                testScript = ''
+                  cfg = "/home/tester/.cache/lemonade/config.json"
+
+                  machine.wait_for_unit("multi-user.target")
+
+                  # A config as a pre-existing host holds it: one module-managed key
+                  # gone stale, one key only the user or web UI ever sets. The
+                  # user-only key is ctx_size rather than host/port because lemond
+                  # persists those two from its own flags after the hook has run
+                  # (main.cpp:82-99), so they would prove nothing here.
+                  machine.succeed("mkdir -p /home/tester/.cache/lemonade")
+                  machine.succeed(
+                      "printf '%s' "
+                      "'{\"ctx_size\":8192,\"max_loaded_models\":1,\"llamacpp\":{\"args\":\"--stale\"}}'"
+                      " > " + cfg
+                  )
+                  machine.succeed("chown -R tester:users /home/tester/.cache")
+
+                  machine.succeed("systemctl start lemond")
+                  machine.wait_for_unit("lemond.service")
+
+                  machine.succeed("jq -e '.max_loaded_models == -1' " + cfg)
+                  machine.succeed("jq -e '.llamacpp.args == \"--flash-attn on\"' " + cfg)
+                  machine.succeed("jq -e '.llamacpp.cpu_bin | startswith(\"/etc/lemonade/backends/\")' " + cfg)
+                  machine.succeed("jq -e '.ctx_size == 8192' " + cfg)
+                  machine.succeed("test $(stat -c %U " + cfg + ") = tester")
+
+                  # No mode assertion: the same CLI-override save rewrites the file
+                  # through a fresh ofstream + rename, resetting it to 0644 on every
+                  # start. module-eval-lemonade-settings covers the hook's own
+                  # mode handling, which is the part we control.
+                '';
+              };
+
             # GTT headroom: configured system emits the ttm modprobe line with
             # GiB→page conversion; default system emits no ttm line.
             module-eval-gtt = let


### PR DESCRIPTION
Closes the deployment gap from #70: every check there is eval-level or runs the hook in isolation, so none could see a hook that aborts and takes lemond down with it. This boots a machine with a pre-existing stale config and asserts lemond reaches `active`, module-declared keys are re-applied, and a user-only key survives.

## What it found

The test failed twice before passing, both times on real behaviour rather than flakiness.

**1. `host`/`port` are module-owned through the CLI, not through `config.json`.** `main.cpp:82-99` persists `--port`/`--host` into the file *after* the hook runs, and the unit always passes both. So `lemonade.settings.host` is silently overwritten — `lemonade.host` is the real option. The test uses `ctx_size` as its user-only key for this reason.

**2. `config.json` cannot be held tighter than 0644 on a host running this module.** That same CLI-override save rewrites the file through a fresh `ofstream` + rename (`config_file.cpp:162-172`), resetting the mode on every start. The `chmod --reference` added in #70 is still correct — our hook shouldn't be the thing that widens — but it cannot reach a 0600 end state, so I dropped that assertion from the VM test and left it in `module-eval-lemonade-settings` where only our script runs. If `config.json` ever carries a secret, the fix has to be upstream in `ConfigFile::save`.

Both are documented in the README's settings section.

## Note on the module

The test imports `./modules/amd-npu.nix` rather than `nixosModules.default`, which bundles `nixpkgs.overlays` as a consumer convenience and collides with the test framework pinning nixpkgs read-only. The overlay comes in through the driving pkgs instead. I chose not to change the module's public contract to suit a test, but it does mean the packaged module and the bare module are now exercised by different checks.

## ⚠️ CI cost — worth a look before merging

`nix flake check` runs on `ubuntu-latest` (`build.yml:25`), so this now boots QEMU in CI. If the runner exposes `/dev/kvm` that's a couple of minutes; without it QEMU falls back to TCG emulation and the job gets substantially slower. I can't determine that from here — this PR's own CI run is the experiment.

If it turns out slow, the alternative is moving `lemond-vm` out of `checks` into a separate attribute run on demand or on a schedule, at the cost of it no longer gating every push.

Locally: all 10 checks green, VM test ~1 min with KVM.