### PR TITLE
ci: stream flake-check build logs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,7 +22,10 @@ jobs:
       - name: Build all packages
         run: nix build .#xrt .#xrt-plugin-amdxdna .#fastflowlm .#lemonade .#ds4
       - name: Check flake
-        run: nix flake check
+        # -L so NixOS VM tests stream their boot and assertions into the job log.
+        # Without it a VM test is a bare ✅/❌ line — indistinguishable from one
+        # that never ran, and undiagnosable when it fails.
+        run: nix flake check -L
       - name: Verify lemond unit (systemd-analyze)
         run: |
           unit=$(nix build .#lemond-unit --print-out-paths)/lemond.service


### PR DESCRIPTION
Pairs with #72. One flag, but it closes a real gap that PR exposed.

## Why

`nix flake check` prints a bare ✅/❌ per check and swallows the underlying build log. For the eval checks that's fine — they assert with `grep`/`jq`, so the failure message *is* the assertion.

For a NixOS VM test it isn't. The machine boots, runs its assertions and exits with **nothing** in the job log. Two consequences:

- A passing VM test is indistinguishable from one substituted from Cachix rather than actually run. That came up concretely on #72 — confirming the VM really booted meant digging through the raw job log for a `building '…vm-test-run-….drv'` line and the *absence* of a `copying path` line.
- A failing VM test gives you the check name and nothing else; you have to reproduce it locally to see which assertion blew up.

With `-L` the boot and every `must succeed:` line land in the job log.

## Scope

Linux job only. The darwin job runs the same `nix flake check`, but the Linux-only checks are gated out there, so it has no VM test to stream.

`update.yml` runs `nix flake check --no-build`, which is eval-only by design — untouched.

## Cost

Log volume only. For reference the VM test itself adds ~24 s to the job (2m3s → 2m27s), measured on #72.

## Merge order

Harmless either way, but only does anything once #72 lands — that's the PR that introduces a VM test. The comment is deliberately worded not to name `lemond-vm`, so it reads correctly if this merges first.

actionlint clean.