### PR TITLE
docs(vllm): state what is actually verified on gfx1151

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,12 +172,14 @@ Python + torch + TheRock-ROCm bundle instead (interpreter-patched, not
 autoPatchelf'd, which would inject mismatched nixpkgs libs and segfault torch).
 It's off by default and adds a ~7.6 GB closure with no binary-cache substituter.
 
-Validated on gfx1150 (standalone and through lemonade's OpenAI API); the
-`gfx1151` (Strix Halo) target is pinned and builds but hasn't been run on a Halo
-host yet. On gfx1150 our benchmarks still put Vulkan ahead of ROCm and vLLM's
-batching doesn't help single-user workloads, so `enableVllm` mainly matters on
-gfx1151 (where the Vulkan-fills-VRAM-first freeze on X11 makes the ROCm path
-worthwhile) or for vLLM-specific features.
+Validated on gfx1150 (standalone and through lemonade's OpenAI API). The
+`gfx1151` (Strix Halo) target builds and its `vllm-server` launches — torch and
+vLLM import cleanly, so the packaging carries over — but no gfx1151 kernel has
+run, because there is no Halo host to run it on. On gfx1150 our benchmarks
+still put Vulkan ahead of ROCm and vLLM's batching doesn't help single-user
+workloads, so `enableVllm` mainly matters on gfx1151 (where the
+Vulkan-fills-VRAM-first freeze on X11 makes the ROCm path worthwhile) or for
+vLLM-specific features.
 
 Vanilla v10.5.0 ignores these env vars on NixOS for several reasons that this flake patches in-tree (see `pkgs/lemonade/default.nix:postPatch`, [issue #5](https://github.com/noamsto/nix-amd-ai/issues/5), upstream [lemonade-sdk/lemonade#1791](https://github.com/lemonade-sdk/lemonade/issues/1791)):
 

--- a/pkgs/vllm-rocm/sources.nix
+++ b/pkgs/vllm-rocm/sources.nix
@@ -18,9 +18,10 @@
     ];
   };
 
-  # Strix Halo. Hashes pinned; buildable, but not yet run on a Halo host — the
-  # gfx1150 recipe transfers, so this is expected to work. Validate inference on
-  # a gfx1151 machine before treating it as confirmed. See noamsto/nix-amd-ai#63.
+  # Strix Halo. Packaging is verified: this bundle unpacks and its `vllm-server
+  # --help` imports torch + vLLM, so the relocation covers gfx1151 too. No
+  # gfx1151 kernel has ever executed though — we have no Halo host. Validate
+  # inference before treating it as confirmed. See noamsto/nix-amd-ai#63, #68.
   gfx1151 = {
     version = "0.23.1.dev0";
     releaseTag = "vllm0.23.1.dev0+rocm7.15.0a20260710.g0fc695fc6.d20260710-rocm7.15.0-gfx1151";


### PR DESCRIPTION
`sources.nix` said the gfx1151 bundle was "buildable, but not yet run on a Halo host". That undersold one half and blurred the other.

## What changed factually

The gfx1151 tarball has now been built and its `vllm-server` launched — `--help` exits 0 with torch and vLLM imported. That exercises unpack, chmod, interpreter patch, shebang rewrite, and the `LD_LIBRARY_PATH` wrapper: the entire relocation layer, which was the one part nobody had ever run for this arch.

What remains unverified is now narrower and sharper: **no gfx1151 kernel has executed**, because there is no Halo host. "Not yet run" conflated those two.

Also worth recording, since it shapes how likely inference is to work: `gpuTarget` selects a whole per-arch bundle built by upstream for gfx1151, not a flag on a gfx1150 build — so there is no wrong-kernels-for-this-arch failure mode to worry about.

## Scope

The same claim appeared in the README ("pinned and builds but hasn't been run on a Halo host yet"), updated in the same commit so the two can't drift. Reflowed the surrounding paragraph to the section's existing ~78-col wrap.

Docs only — no evaluated Nix changed. `nix flake check` clean.