### PR TITLE
fix(vllm-rocm): patch the ELF interpreter on every bundled executable

### DIFF
--- a/pkgs/vllm-rocm/default.nix
+++ b/pkgs/vllm-rocm/default.nix
@@ -66,14 +66,20 @@ in
       done
 
       # Repoint the ELF interpreter (FHS /lib64/ld-linux-x86-64.so.2 -> nix
-      # loader) on the executables the launcher actually execs — python3 and the
-      # bundled clang (Triton JIT). Leave every runpath intact.
+      # loader) on every executable in the bundle's bin dirs, not just the ones
+      # the launcher execs directly: clang re-execs clang-N, and torch's
+      # cpp_extension build path shells out to ninja, so a hand-picked list
+      # keeps missing binaries. Leave every runpath intact.
       loader=${stdenv.cc.bintools.dynamicLinker}
-      for exe in $prefix/bin/python3 $prefix/bin/python3.* \
-                 $prefix/lib/python3.*/site-packages/_rocm_sdk_*/lib/llvm/bin/clang; do
-        if [ -f "$exe" ] && patchelf --print-interpreter "$exe" >/dev/null 2>&1; then
-          patchelf --set-interpreter "$loader" "$exe"
-        fi
+      for d in $prefix/bin \
+               $prefix/lib/python3.*/site-packages/_rocm_sdk_*/bin \
+               $prefix/lib/python3.*/site-packages/_rocm_sdk_*/lib/llvm/bin; do
+        [ -d "$d" ] || continue
+        for exe in "$d"/*; do
+          if [ -f "$exe" ] && patchelf --print-interpreter "$exe" >/dev/null 2>&1; then
+            patchelf --set-interpreter "$loader" "$exe"
+          fi
+        done
       done
 
       # Launcher shebang is #!/bin/bash (FHS); rewrite to the nix bash.


### PR DESCRIPTION
The installPhase patched the ELF interpreter on a hand-picked list of executables — `bin/python3`, `bin/python3.*`, and `llvm/bin/clang` — with a comment saying the intent was to cover "the bundled clang (Triton JIT)". That intent was not met.

`llvm/bin/clang` is a ~30 KB driver that re-execs `llvm/bin/clang-23`, confirmed with `strace -f -e trace=execve` on a real compile. The launcher sets `CC` to that driver, so `clang-23` is the compiler Triton's JIT actually invokes — and its interpreter was left as `/lib64/ld-linux-x86-64.so.2`. Same class of failure as lemonade-sdk/vllm-rocm#16.

Scanning all three bin directories found **21** executables with an unpatched FHS interpreter, not one. Besides `clang-23` and 17 auxiliary `clang-*` tools, the runtime-relevant ones are `ninja` (torch's `cpp_extension` build path) and `python` — the bare alias, missed because the glob only covered `python3` and `python3.*`.

## Why it worked anyway

`programs.nix-ld` is enabled by `modules/amd-npu.nix` (via `mkDefault`, for the koko TTS prebuilt), and nix-ld provides `/lib64/ld-linux-x86-64.so.2`. So the bundle rides a loader enabled for an unrelated reason. It breaks in two supported situations: a host that opts out of nix-ld — which the `mkDefault` exists to allow — and anyone using the standalone `#vllm-rocm` package outside the module, which neither depends on nor documents nix-ld.

## Verification

Both targets built and scanned. `_rocm_sdk_*/bin` does not exist in either bundle, so that glob is currently a no-op, kept only for other gfx targets.

| | gfx1150 | gfx1151 |
|---|---|---|
| ELF executables | 24 | 24 |
| unpatched before | 21 | — |
| unpatched after | **0** | **0** |
| `vllm-server --help` | exit 0 | exit 0 |

`vllm-server --help` is the regression gate: it exits 0 with torch and vLLM importing cleanly, which is the failure autoPatchelf historically caused here. RUNPATHs verified unchanged on `libtorch_python.so`, `bin/python3.14`, and `clang-23`.

Decisive test — bundled `clang -c` under the wrapper's real `LD_LIBRARY_PATH`, inside a mount namespace with a tmpfs over `/lib64` (i.e. a host without nix-ld):

| | `/lib64` present | `/lib64` hidden |
|---|---|---|
| before | COMPILE_OK | `could not exec .../clang-23` |
| after | COMPILE_OK | COMPILE_OK |

## Scope

This does **not** break all Triton JIT — a basic elementwise Triton kernel compiles and runs without ever invoking `CC`, verified on gfx1150 hardware with a cold `TRITON_CACHE_DIR`. The blast radius is limited to paths that genuinely shell out to the C compiler. It is not a cause of slow inference.

No autoPatchelf, no RUNPATH changes — consistent with the header comment's reasoning.
