### PR TITLE
feat(module): lemonade allowedOrigins, gfx1151 CWSR warning, gpuTarget option, docs fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -239,6 +239,15 @@ rewrites the file through a fresh `ofstream` + rename, which resets its mode to
 `0644` on every start; the hook preserves whatever mode it finds, but it cannot
 hold the file tighter than lemond leaves it.
 
+Lemonade >=11.5.0 stopped sending `Access-Control-Allow-Origin: *` by
+default, so non-loopback browsers get a 403 `Origin not allowed` unless their
+origin is listed in `LEMONADE_ALLOWED_ORIGINS`. Like host/port, this is env-only
+— there is no config.json key, so `lemonade.settings` cannot reach it; set
+`lemonade.allowedOrigins` instead. Loopback origins and non-http(s) desktop
+schemes are always allowed, so this only matters once `lemonade.host` is
+bound to something a LAN or remote browser can reach; the module warns if
+you set the former without the latter.
+
 ### Tauri desktop app: download progress is fragile when backgrounded
 
 WebKitGTK suspends the network process for windows that are minimized, hidden, or moved to another workspace. That kills the SSE progress stream lemond uses for downloads at ~60–90 s. Without our patch, that nuked the whole download mid-flight. With the patch, the download keeps running server-side and finishes regardless — but the UI stops seeing progress until you refocus the window (and may need a refresh to pick up the result). For very large pulls, prefer the regular browser at `http://localhost:13305` or `lemonade pull <model>` from the CLI; both survive backgrounding cleanly.

--- a/README.md
+++ b/README.md
@@ -460,7 +460,7 @@ whispercpp          cpu         installed       v1.8.4
                     vulkan      installed       v1.8.4
 ```
 
-Quick image-gen smoke test (ROCm path):
+Quick image-gen smoke test:
 
 ```bash
 lemonade pull SD-Turbo
@@ -470,7 +470,7 @@ curl -s -X POST http://localhost:13305/api/v1/images/generations \
   | jq -r '.data[0].b64_json' | base64 -d > out.png
 ```
 
-Lemond logs should show `Starting server on port 8001 (backend: rocm)` and *no* `Installing sd-server` line — sd-server is invoked directly from the nix store.
+With both `enableROCm` and `enableVulkan` set, lemond logs should show `Starting server on port 8001 (backend: vulkan)` and *no* `Installing sd-server` line — sd-server is invoked directly from the nix store. sd-cpp's `auto` backend selection prefers Vulkan whenever both variants are already installed: 11.5.1 made that the case for every engine (llamacpp, sd-cpp, whispercpp), matching llamacpp's pre-existing Vulkan-first preference order. To exercise the ROCm path specifically, pin it with `hardware.amd-npu.lemonade.settings.sdcpp.backend = "rocm";` (the runtime config section is `sdcpp`, not `sd-cpp`).
 
 ### Benchmarking
 

--- a/flake.nix
+++ b/flake.nix
@@ -325,11 +325,9 @@
                 ];
               }).config.systemd.services.lemond.environment.LEMONADE_DEFAULTS_PATH;
 
-            # gfx1151 + ROCm below the CWSR-fix kernel version must warn (not
-            # assert — the fix may be backported to an older kernel), whether the
-            # signal is gpuTarget (the real-hardware knob) or the legacy
-            # vllmGpuTarget (kept for back-compat); gfx1150 and an already-new-
-            # enough kernel must both stay silent.
+            # The warning must fire on gfx1151 below the CWSR-fix kernel whether
+            # the signal is gpuTarget or the older vllmGpuTarget, and stay silent
+            # on gfx1150 or a new-enough kernel.
             module-eval-cwsr-warning = let
               mkSys = extraModule:
                 (inputs.nixpkgs.lib.nixosSystem {
@@ -394,14 +392,14 @@
                 old1150 = builtins.toJSON oldKernelGfx1150;
                 new1151 = builtins.toJSON newKernelGfx1151;
                 passAsFile = ["old1151NoVllm" "old1151VllmOn" "oldExplicitVllmTargetOnly" "old1150" "new1151"];
-              } "
-                grep -q cwsr_size \"$old1151NoVllmPath\" || { echo \"gfx1151 + old kernel, vLLM off, via gpuTarget must warn\"; exit 1; }
-                grep -q cwsr_size \"$old1151VllmOnPath\" || { echo \"gfx1151 + old kernel + vLLM on must warn\"; exit 1; }
-                grep -q cwsr_size \"$oldExplicitVllmTargetOnlyPath\" || { echo \"legacy vllmGpuTarget-only config must still warn\"; exit 1; }
-                grep -q cwsr_size \"$old1150Path\" && { echo \"gfx1150 must not warn\"; exit 1; }
-                grep -q cwsr_size \"$new1151Path\" && { echo \"gfx1151 + new kernel must not warn\"; exit 1; }
+              } ''
+                grep -q cwsr_size "$old1151NoVllmPath" || { echo "gfx1151 + old kernel, vLLM off, via gpuTarget must warn"; exit 1; }
+                grep -q cwsr_size "$old1151VllmOnPath" || { echo "gfx1151 + old kernel + vLLM on must warn"; exit 1; }
+                grep -q cwsr_size "$oldExplicitVllmTargetOnlyPath" || { echo "legacy vllmGpuTarget-only config must still warn"; exit 1; }
+                grep -q cwsr_size "$old1150Path" && { echo "gfx1150 must not warn"; exit 1; }
+                grep -q cwsr_size "$new1151Path" && { echo "gfx1151 + new kernel must not warn"; exit 1; }
                 touch $out
-              ";
+              '';
 
             # lemonade.settings must deep-merge over the module's computed
             # defaults — overriding one key without dropping its siblings — and

--- a/flake.nix
+++ b/flake.nix
@@ -326,8 +326,10 @@
               }).config.systemd.services.lemond.environment.LEMONADE_DEFAULTS_PATH;
 
             # gfx1151 + ROCm below the CWSR-fix kernel version must warn (not
-            # assert — the fix may be backported to an older kernel); gfx1150
-            # and an already-new-enough kernel must both stay silent.
+            # assert — the fix may be backported to an older kernel), whether the
+            # signal is gpuTarget (the real-hardware knob) or the legacy
+            # vllmGpuTarget (kept for back-compat); gfx1150 and an already-new-
+            # enough kernel must both stay silent.
             module-eval-cwsr-warning = let
               mkSys = extraModule:
                 (inputs.nixpkgs.lib.nixosSystem {
@@ -335,45 +337,67 @@
                   modules = [
                     inputs.self.nixosModules.default
                     (pkgs.lib.recursiveUpdate {
-                      boot.loader.grub.enable = false;
-                      fileSystems."/" = {
-                        device = "/dev/sda1";
-                        fsType = "ext4";
-                      };
-                      hardware.amd-npu = {
-                        enable = true;
-                        enableNPU = false;
-                        enableFastFlowLM = false;
-                        enableLemonade = true;
-                        enableROCm = true;
-                        lemonade.user = "testuser";
-                      };
-                      users.users.testuser = {
-                        isNormalUser = true;
-                        extraGroups = ["video" "render"];
-                      };
-                    } extraModule)
+                        boot.loader.grub.enable = false;
+                        fileSystems."/" = {
+                          device = "/dev/sda1";
+                          fsType = "ext4";
+                        };
+                        hardware.amd-npu = {
+                          enable = true;
+                          enableNPU = false;
+                          enableFastFlowLM = false;
+                          enableLemonade = true;
+                          enableROCm = true;
+                          lemonade.user = "testuser";
+                        };
+                        users.users.testuser = {
+                          isNormalUser = true;
+                          extraGroups = ["video" "render"];
+                        };
+                      }
+                      extraModule)
                   ];
                 }).config.warnings;
-              oldKernelGfx1151 = mkSys {
+              # The bug this check guards: an llamacpp-only gfx1151 host that
+              # never touches vllmGpuTarget used to get no warning at all.
+              oldKernelGfx1151NoVllm = mkSys {
+                hardware.amd-npu.gpuTarget = "gfx1151";
+                boot.kernelPackages = pkgs.linuxPackages_6_12;
+              };
+              oldKernelGfx1151VllmOn = mkSys {
+                hardware.amd-npu = {
+                  gpuTarget = "gfx1151";
+                  enableVllm = true;
+                  vllmGpuTarget = "gfx1151";
+                };
+                boot.kernelPackages = pkgs.linuxPackages_6_12;
+              };
+              # Back-compat: an existing config that only ever set the legacy
+              # vLLM-only knob must keep warning, even though gpuTarget defaults
+              # to gfx1150.
+              oldKernelExplicitVllmTargetOnly = mkSys {
                 hardware.amd-npu.vllmGpuTarget = "gfx1151";
                 boot.kernelPackages = pkgs.linuxPackages_6_12;
               };
               oldKernelGfx1150 = mkSys {
-                hardware.amd-npu.vllmGpuTarget = "gfx1150";
+                hardware.amd-npu.gpuTarget = "gfx1150";
                 boot.kernelPackages = pkgs.linuxPackages_6_12;
               };
               newKernelGfx1151 = mkSys {
-                hardware.amd-npu.vllmGpuTarget = "gfx1151";
+                hardware.amd-npu.gpuTarget = "gfx1151";
               };
             in
               pkgs.runCommand "module-eval-cwsr-warning" {
-                old1151 = builtins.toJSON oldKernelGfx1151;
+                old1151NoVllm = builtins.toJSON oldKernelGfx1151NoVllm;
+                old1151VllmOn = builtins.toJSON oldKernelGfx1151VllmOn;
+                oldExplicitVllmTargetOnly = builtins.toJSON oldKernelExplicitVllmTargetOnly;
                 old1150 = builtins.toJSON oldKernelGfx1150;
                 new1151 = builtins.toJSON newKernelGfx1151;
-                passAsFile = ["old1151" "old1150" "new1151"];
+                passAsFile = ["old1151NoVllm" "old1151VllmOn" "oldExplicitVllmTargetOnly" "old1150" "new1151"];
               } "
-                grep -q cwsr_size \"$old1151Path\" || { echo \"gfx1151 + old kernel must warn\"; exit 1; }
+                grep -q cwsr_size \"$old1151NoVllmPath\" || { echo \"gfx1151 + old kernel, vLLM off, via gpuTarget must warn\"; exit 1; }
+                grep -q cwsr_size \"$old1151VllmOnPath\" || { echo \"gfx1151 + old kernel + vLLM on must warn\"; exit 1; }
+                grep -q cwsr_size \"$oldExplicitVllmTargetOnlyPath\" || { echo \"legacy vllmGpuTarget-only config must still warn\"; exit 1; }
                 grep -q cwsr_size \"$old1150Path\" && { echo \"gfx1150 must not warn\"; exit 1; }
                 grep -q cwsr_size \"$new1151Path\" && { echo \"gfx1151 + new kernel must not warn\"; exit 1; }
                 touch $out

--- a/flake.nix
+++ b/flake.nix
@@ -325,6 +325,60 @@
                 ];
               }).config.systemd.services.lemond.environment.LEMONADE_DEFAULTS_PATH;
 
+            # gfx1151 + ROCm below the CWSR-fix kernel version must warn (not
+            # assert — the fix may be backported to an older kernel); gfx1150
+            # and an already-new-enough kernel must both stay silent.
+            module-eval-cwsr-warning = let
+              mkSys = extraModule:
+                (inputs.nixpkgs.lib.nixosSystem {
+                  inherit system;
+                  modules = [
+                    inputs.self.nixosModules.default
+                    (pkgs.lib.recursiveUpdate {
+                      boot.loader.grub.enable = false;
+                      fileSystems."/" = {
+                        device = "/dev/sda1";
+                        fsType = "ext4";
+                      };
+                      hardware.amd-npu = {
+                        enable = true;
+                        enableNPU = false;
+                        enableFastFlowLM = false;
+                        enableLemonade = true;
+                        enableROCm = true;
+                        lemonade.user = "testuser";
+                      };
+                      users.users.testuser = {
+                        isNormalUser = true;
+                        extraGroups = ["video" "render"];
+                      };
+                    } extraModule)
+                  ];
+                }).config.warnings;
+              oldKernelGfx1151 = mkSys {
+                hardware.amd-npu.vllmGpuTarget = "gfx1151";
+                boot.kernelPackages = pkgs.linuxPackages_6_12;
+              };
+              oldKernelGfx1150 = mkSys {
+                hardware.amd-npu.vllmGpuTarget = "gfx1150";
+                boot.kernelPackages = pkgs.linuxPackages_6_12;
+              };
+              newKernelGfx1151 = mkSys {
+                hardware.amd-npu.vllmGpuTarget = "gfx1151";
+              };
+            in
+              pkgs.runCommand "module-eval-cwsr-warning" {
+                old1151 = builtins.toJSON oldKernelGfx1151;
+                old1150 = builtins.toJSON oldKernelGfx1150;
+                new1151 = builtins.toJSON newKernelGfx1151;
+                passAsFile = ["old1151" "old1150" "new1151"];
+              } "
+                grep -q cwsr_size \"$old1151Path\" || { echo \"gfx1151 + old kernel must warn\"; exit 1; }
+                grep -q cwsr_size \"$old1150Path\" && { echo \"gfx1150 must not warn\"; exit 1; }
+                grep -q cwsr_size \"$new1151Path\" && { echo \"gfx1151 + new kernel must not warn\"; exit 1; }
+                touch $out
+              ";
+
             # lemonade.settings must deep-merge over the module's computed
             # defaults — overriding one key without dropping its siblings — and
             # the unit must re-apply them on every start, else the option is

--- a/flake.nix
+++ b/flake.nix
@@ -388,6 +388,43 @@
                 touch $out
               '';
 
+            module-eval-lemonade-allowed-origins = let
+              sys =
+                (inputs.nixpkgs.lib.nixosSystem {
+                  inherit system;
+                  modules = [
+                    inputs.self.nixosModules.default
+                    {
+                      boot.loader.grub.enable = false;
+                      fileSystems."/" = {
+                        device = "/dev/sda1";
+                        fsType = "ext4";
+                      };
+                      hardware.amd-npu = {
+                        enable = true;
+                        enableLemonade = true;
+                        lemonade = {
+                          user = "testuser";
+                          host = "0.0.0.0";
+                          allowedOrigins = ["https://app.example.com" "http://192.168.1.10:3000"];
+                        };
+                      };
+                      users.users.testuser = {
+                        isNormalUser = true;
+                        extraGroups = ["video" "render"];
+                      };
+                    }
+                  ];
+                }).config;
+            in
+              pkgs.runCommand "module-eval-lemonade-allowed-origins" {
+                unit = sys.systemd.units."lemond.service".unit;
+              } ''
+                grep -qF 'Environment="LEMONADE_ALLOWED_ORIGINS=https://app.example.com,http://192.168.1.10:3000"' "$unit"/lemond.service
+
+                touch $out
+              '';
+
             # The checks above prove the unit renders and that the hook behaves
             # when invoked by hand. This one boots it: lemond must actually reach
             # active with the ExecStartPre in front of it. That is the failure

--- a/flake.nix
+++ b/flake.nix
@@ -559,6 +559,8 @@
                 || { echo "missing/changed NIX_LD"; exit 1; }
               grep -q 'NIX_LD_LIBRARY_PATH=/run/current-system/sw/share/nix-ld/lib' "$unit" \
                 || { echo "missing/changed NIX_LD_LIBRARY_PATH"; exit 1; }
+              ! grep -q 'LEMONADE_ALLOWED_ORIGINS' "$unit" \
+                || { echo "LEMONADE_ALLOWED_ORIGINS set on a host that never listed origins"; exit 1; }
               touch $out
             '';
 

--- a/modules/amd-npu.nix
+++ b/modules/amd-npu.nix
@@ -204,10 +204,9 @@ in {
       default = "gfx1150";
       description = ''
         The host's actual iGPU: gfx1150 (Strix Point) or gfx1151 (Strix
-        Halo). Drives the gfx1151 CWSR-kernel warning below and the default
-        for vllmGpuTarget — set this instead of vllmGpuTarget on
-        llamacpp/sd-cpp-only hosts, since vllmGpuTarget's own default never
-        applies without enableVllm.
+        Halo). Drives the gfx1151 CWSR-kernel warning and the default for
+        vllmGpuTarget, so a llamacpp/sd-cpp-only host still declares its
+        chip without touching a vLLM option.
       '';
     };
 
@@ -295,19 +294,15 @@ in {
         default = [];
         example = ["https://app.example.com" "http://192.168.1.10:3000"];
         description = ''
-          Origins allowed to make cross-origin browser requests, set via
-          `LEMONADE_ALLOWED_ORIGINS`. 11.5.0 dropped the
-          `Access-Control-Allow-Origin: *` default and this is
-          env-only — there is no config.json key, so `lemonade.settings`
-          cannot reach it. Loopback origins (localhost, 127.0.0.1, ::1,
-          *.localhost) and non-http(s) desktop schemes (tauri://, file://,
-          vscode-webview://) are always allowed regardless of this setting,
-          so it is only needed for browsers on other machines reaching a
-          non-loopback `lemonade.host`. `["*"]` allows any
-          origin — combine with an API key (upstream's
-          `LEMONADE_API_KEY`, not wired up here) or requests are
-          unauthenticated and open to cross-origin attacks from any site the
-          browser visits.
+          Origins allowed to make cross-origin browser requests, emitted as
+          `LEMONADE_ALLOWED_ORIGINS`. Env-only upstream — there is no
+          config.json key, so `lemonade.settings` cannot reach it.
+
+          Loopback and non-http(s) desktop schemes (tauri://, file://) are
+          always allowed, so this is only needed for browsers on other
+          machines reaching a non-loopback `lemonade.host`. `["*"]` allows
+          any origin, which without an API key leaves the server open to any
+          site the browser visits.
         '';
       };
     };
@@ -439,12 +434,10 @@ in {
       optional
       (cfg.enableLemonade && cfg.lemonade.allowedOrigins == [] && !builtins.elem cfg.lemonade.host ["localhost" "127.0.0.1" "::1"])
       "hardware.amd-npu.lemonade.host is non-loopback but lemonade.allowedOrigins is empty; browsers on other machines will get a 403 'Origin not allowed' error. Set lemonade.allowedOrigins to the origins that should reach it."
-      # gfx1151 requires a kernel with the CWSR VGPR-count fix or ROCm can crash
-      # any ROCm backend (llamacpp:rocm, sd-cpp:rocm, vllm:rocm), not just vllm,
-      # so this checks gpuTarget (the host's real chip) too — vllmGpuTarget
-      # alone misses llamacpp/sd-cpp-only hosts that never touch it.
-      # A warning, not an assertion: the fix can be backported to a kernel older
-      # than 6.18.4, which a bare version check cannot detect.
+      # Checks gpuTarget as well as vllmGpuTarget: the CWSR bug crashes every
+      # ROCm backend, so a llamacpp-only gfx1151 host must warn too.
+      # A warning rather than an assertion — the fix can be backported to an
+      # older kernel, which a version check cannot detect.
       ++ optional
       (cfg.enableLemonade
         && cfg.enableROCm

--- a/modules/amd-npu.nix
+++ b/modules/amd-npu.nix
@@ -195,9 +195,7 @@ in {
       description = ''
         Whether to wire the vLLM ROCm backend (vllm:rocm) into lemonade,
         repackaged from the upstream lemonade-sdk/vllm-rocm prebuilt. Requires
-        enableROCm. Strix Halo (gfx1151) needs a kernel with the CWSR fix;
-        lemonade reports vllm:rocm as unsupported otherwise. Experimental —
-        see noamsto/nix-amd-ai#63.
+        enableROCm. Experimental — see noamsto/nix-amd-ai#63.
       '';
     };
 
@@ -207,7 +205,9 @@ in {
       description = ''
         Which lemonade-sdk/vllm-rocm prebuilt to install: gfx1150 (Strix Point)
         or gfx1151 (Strix Halo). Each bundles a TheRock ROCm built for that
-        exact target.
+        exact target. gfx1151 needs a kernel with the CWSR fix, backported or
+        not, or ROCm can crash any ROCm backend, not just vLLM (see the
+        eval-time warning this module emits when enableROCm is also set).
       '';
     };
 
@@ -398,6 +398,18 @@ in {
         message = "hardware.amd-npu.gpuMemory.pagePoolSizeGiB must be <= ttmSizeGiB.";
       }
     ];
+
+    # gfx1151 requires a kernel with the CWSR VGPR-count fix or ROCm can crash
+    # any ROCm backend (llamacpp:rocm, sd-cpp:rocm, vllm:rocm), not just vllm.
+    # A warning, not an assertion: the fix can be backported to a kernel older
+    # than 6.18.4, which a bare version check cannot detect.
+    warnings =
+      optional
+      (cfg.enableLemonade
+        && cfg.enableROCm
+        && cfg.vllmGpuTarget == "gfx1151"
+        && !versionAtLeast config.boot.kernelPackages.kernel.version "6.18.4")
+      "hardware.amd-npu.vllmGpuTarget = \"gfx1151\" needs Linux kernel >= 6.18.4 (or the CWSR fix backported) or ROCm can miscalculate VGPR counts and crash llamacpp:rocm, sd-cpp:rocm, and vllm:rocm. Kernel ${config.boot.kernelPackages.kernel.version} is below that; if it carries a backported fix, verify on the host with: grep -E \"cwsr_size|ctl_stack_size\" /sys/class/kfd/kfd/topology/nodes/*/properties";
 
     # Kernel configuration (NPU-only)
     boot.kernelModules = optionals cfg.enableNPU ["amdxdna"];

--- a/modules/amd-npu.nix
+++ b/modules/amd-npu.nix
@@ -214,6 +214,7 @@ in {
     vllmGpuTarget = mkOption {
       type = types.enum ["gfx1150" "gfx1151"];
       default = cfg.gpuTarget;
+      defaultText = lib.literalExpression "config.hardware.amd-npu.gpuTarget";
       description = ''
         Which lemonade-sdk/vllm-rocm prebuilt to install: gfx1150 (Strix Point)
         or gfx1151 (Strix Halo). Each bundles a TheRock ROCm built for that
@@ -449,7 +450,7 @@ in {
         && cfg.enableROCm
         && (cfg.gpuTarget == "gfx1151" || cfg.vllmGpuTarget == "gfx1151")
         && !versionAtLeast config.boot.kernelPackages.kernel.version "6.18.4")
-      "hardware.amd-npu.gpuTarget = \"gfx1151\" needs Linux kernel >= 6.18.4 (or the CWSR fix backported) or ROCm can miscalculate VGPR counts and crash llamacpp:rocm, sd-cpp:rocm, and vllm:rocm. Kernel ${config.boot.kernelPackages.kernel.version} is below that; if it carries a backported fix, verify on the host with: grep -E \"cwsr_size|ctl_stack_size\" /sys/class/kfd/kfd/topology/nodes/*/properties";
+      "A gfx1151 target is selected (hardware.amd-npu.gpuTarget / vllmGpuTarget), which needs Linux kernel >= 6.18.4 (or the CWSR fix backported) or ROCm can miscalculate VGPR counts and crash llamacpp:rocm, sd-cpp:rocm, and vllm:rocm. Kernel ${config.boot.kernelPackages.kernel.version} is below that; if it carries a backported fix, verify on the host with: grep -E \"cwsr_size|ctl_stack_size\" /sys/class/kfd/kfd/topology/nodes/*/properties";
 
     # Kernel configuration (NPU-only)
     boot.kernelModules = optionals cfg.enableNPU ["amdxdna"];

--- a/modules/amd-npu.nix
+++ b/modules/amd-npu.nix
@@ -199,15 +199,29 @@ in {
       '';
     };
 
-    vllmGpuTarget = mkOption {
+    gpuTarget = mkOption {
       type = types.enum ["gfx1150" "gfx1151"];
       default = "gfx1150";
       description = ''
+        The host's actual iGPU: gfx1150 (Strix Point) or gfx1151 (Strix
+        Halo). Drives the gfx1151 CWSR-kernel warning below and the default
+        for vllmGpuTarget — set this instead of vllmGpuTarget on
+        llamacpp/sd-cpp-only hosts, since vllmGpuTarget's own default never
+        applies without enableVllm.
+      '';
+    };
+
+    vllmGpuTarget = mkOption {
+      type = types.enum ["gfx1150" "gfx1151"];
+      default = cfg.gpuTarget;
+      description = ''
         Which lemonade-sdk/vllm-rocm prebuilt to install: gfx1150 (Strix Point)
         or gfx1151 (Strix Halo). Each bundles a TheRock ROCm built for that
-        exact target. gfx1151 needs a kernel with the CWSR fix, backported or
-        not, or ROCm can crash any ROCm backend, not just vLLM (see the
-        eval-time warning this module emits when enableROCm is also set).
+        exact target. Defaults to gpuTarget; override only if vLLM needs a
+        different target than the host's real chip (e.g. testing). gfx1151
+        needs a kernel with the CWSR fix, backported or not, or ROCm can
+        crash any ROCm backend, not just vLLM (see the eval-time warning
+        this module emits when enableROCm is also set).
       '';
     };
 
@@ -425,15 +439,17 @@ in {
       (cfg.enableLemonade && cfg.lemonade.allowedOrigins == [] && !builtins.elem cfg.lemonade.host ["localhost" "127.0.0.1" "::1"])
       "hardware.amd-npu.lemonade.host is non-loopback but lemonade.allowedOrigins is empty; browsers on other machines will get a 403 'Origin not allowed' error. Set lemonade.allowedOrigins to the origins that should reach it."
       # gfx1151 requires a kernel with the CWSR VGPR-count fix or ROCm can crash
-      # any ROCm backend (llamacpp:rocm, sd-cpp:rocm, vllm:rocm), not just vllm.
+      # any ROCm backend (llamacpp:rocm, sd-cpp:rocm, vllm:rocm), not just vllm,
+      # so this checks gpuTarget (the host's real chip) too — vllmGpuTarget
+      # alone misses llamacpp/sd-cpp-only hosts that never touch it.
       # A warning, not an assertion: the fix can be backported to a kernel older
       # than 6.18.4, which a bare version check cannot detect.
       ++ optional
       (cfg.enableLemonade
         && cfg.enableROCm
-        && cfg.vllmGpuTarget == "gfx1151"
+        && (cfg.gpuTarget == "gfx1151" || cfg.vllmGpuTarget == "gfx1151")
         && !versionAtLeast config.boot.kernelPackages.kernel.version "6.18.4")
-      "hardware.amd-npu.vllmGpuTarget = \"gfx1151\" needs Linux kernel >= 6.18.4 (or the CWSR fix backported) or ROCm can miscalculate VGPR counts and crash llamacpp:rocm, sd-cpp:rocm, and vllm:rocm. Kernel ${config.boot.kernelPackages.kernel.version} is below that; if it carries a backported fix, verify on the host with: grep -E \"cwsr_size|ctl_stack_size\" /sys/class/kfd/kfd/topology/nodes/*/properties";
+      "hardware.amd-npu.gpuTarget = \"gfx1151\" needs Linux kernel >= 6.18.4 (or the CWSR fix backported) or ROCm can miscalculate VGPR counts and crash llamacpp:rocm, sd-cpp:rocm, and vllm:rocm. Kernel ${config.boot.kernelPackages.kernel.version} is below that; if it carries a backported fix, verify on the host with: grep -E \"cwsr_size|ctl_stack_size\" /sys/class/kfd/kfd/topology/nodes/*/properties";
 
     # Kernel configuration (NPU-only)
     boot.kernelModules = optionals cfg.enableNPU ["amdxdna"];

--- a/modules/amd-npu.nix
+++ b/modules/amd-npu.nix
@@ -274,6 +274,27 @@ in {
           persisted in `''${LEMONADE_CACHE_DIR:-~/.cache/lemonade}/config.json`.
         '';
       };
+
+      allowedOrigins = mkOption {
+        type = types.listOf types.str;
+        default = [];
+        example = ["https://app.example.com" "http://192.168.1.10:3000"];
+        description = ''
+          Origins allowed to make cross-origin browser requests, set via
+          `LEMONADE_ALLOWED_ORIGINS`. 11.5.0 dropped the
+          `Access-Control-Allow-Origin: *` default and this is
+          env-only — there is no config.json key, so `lemonade.settings`
+          cannot reach it. Loopback origins (localhost, 127.0.0.1, ::1,
+          *.localhost) and non-http(s) desktop schemes (tauri://, file://,
+          vscode-webview://) are always allowed regardless of this setting,
+          so it is only needed for browsers on other machines reaching a
+          non-loopback `lemonade.host`. `["*"]` allows any
+          origin — combine with an API key (upstream's
+          `LEMONADE_API_KEY`, not wired up here) or requests are
+          unauthenticated and open to cross-origin attacks from any site the
+          browser visits.
+        '';
+      };
     };
 
     ds4 = {
@@ -399,6 +420,11 @@ in {
       }
     ];
 
+    warnings =
+      optional
+      (cfg.enableLemonade && cfg.lemonade.allowedOrigins == [] && !builtins.elem cfg.lemonade.host ["localhost" "127.0.0.1" "::1"])
+      "hardware.amd-npu.lemonade.host is non-loopback but lemonade.allowedOrigins is empty; browsers on other machines will get a 403 'Origin not allowed' error. Set lemonade.allowedOrigins to the origins that should reach it.";
+
     # Kernel configuration (NPU-only)
     boot.kernelModules = optionals cfg.enableNPU ["amdxdna"];
 
@@ -519,6 +545,11 @@ in {
           # them, so koko's loader can't find them without re-exporting here.
           NIX_LD = config.environment.sessionVariables.NIX_LD;
           NIX_LD_LIBRARY_PATH = config.environment.sessionVariables.NIX_LD_LIBRARY_PATH;
+        }
+        // optionalAttrs (cfg.lemonade.allowedOrigins != []) {
+          # env-only in lemonade >=11.5.0 — no config.json key to route this
+          # through lemonade.settings.
+          LEMONADE_ALLOWED_ORIGINS = concatStringsSep "," cfg.lemonade.allowedOrigins;
         };
       serviceConfig = {
         Type = "simple";

--- a/pkgs/vllm-rocm/default.nix
+++ b/pkgs/vllm-rocm/default.nix
@@ -66,14 +66,20 @@ in
       done
 
       # Repoint the ELF interpreter (FHS /lib64/ld-linux-x86-64.so.2 -> nix
-      # loader) on the executables the launcher actually execs — python3 and the
-      # bundled clang (Triton JIT). Leave every runpath intact.
+      # loader) on every executable in the bundle's bin dirs, not just the ones
+      # the launcher execs directly: clang re-execs clang-N, and torch's
+      # cpp_extension build path shells out to ninja, so a hand-picked list
+      # keeps missing binaries. Leave every runpath intact.
       loader=${stdenv.cc.bintools.dynamicLinker}
-      for exe in $prefix/bin/python3 $prefix/bin/python3.* \
-                 $prefix/lib/python3.*/site-packages/_rocm_sdk_*/lib/llvm/bin/clang; do
-        if [ -f "$exe" ] && patchelf --print-interpreter "$exe" >/dev/null 2>&1; then
-          patchelf --set-interpreter "$loader" "$exe"
-        fi
+      for d in $prefix/bin \
+               $prefix/lib/python3.*/site-packages/_rocm_sdk_*/bin \
+               $prefix/lib/python3.*/site-packages/_rocm_sdk_*/lib/llvm/bin; do
+        [ -d "$d" ] || continue
+        for exe in "$d"/*; do
+          if [ -f "$exe" ] && patchelf --print-interpreter "$exe" >/dev/null 2>&1; then
+            patchelf --set-interpreter "$loader" "$exe"
+          fi
+        done
       done
 
       # Launcher shebang is #!/bin/bash (FHS); rewrite to the nix bash.


### PR DESCRIPTION
Bundles the lemonade-side work from triaging #68 and #78, plus the `vllm-rocm` fix that is also up standalone as #80 (merging either order is fine).

## `lemonade.allowedOrigins` — fixes #78

lemonade 11.5.0 stopped sending `Access-Control-Allow-Origin: *`; non-loopback browser origins now get a 403. The variable is read via `getenv` in `server.cpp:949` and has **no config.json key**, so `lemonade.settings` structurally cannot reach it — `systemd.services.lemond.environment` was the only escape hatch left to users. This adds a real option, plus a warning when `lemonade.host` is non-loopback and the list is empty.

Reproduced and verified against the running 11.5.1 server:

| Origin | var unset | var set |
|---|---|---|
| `http://localhost:13305` | 200 | — |
| `http://zentraldenker:13305` | **403** | **200** |
| `https://app.example.com` | 403 | **200** |
| `http://192.168.1.50:13305` | 403 | 403 |
| `tauri://localhost` | **200** | — |

Note the last row: 11.5.1 broadened the always-allowed set to any `*.localhost` host and any non-http(s)/ws(s) scheme, so the desktop app needs nothing from us. This only helps LAN/remote browsers. Unlisted origins still 403, so it stays an allowlist.

## gfx1151 CWSR kernel warning

Strix Halo needs kernel ≥ 6.18.4 (or a backport) for the CWSR fix; without it ROCm can miscalculate VGPR counts and crash `llamacpp:rocm`, `sd-cpp:rocm`, and `vllm:rocm`. Upstream only surfaces this as a hint appended to a startup-timeout error.

A warning rather than an assertion, deliberately: the fix can be backported to an older kernel, which a bare version check cannot detect, and a hard failure would block a host that is actually fine.

## `hardware.amd-npu.gpuTarget`

The warning above initially triggered on `vllmGpuTarget`, which is a packaging-only knob defaulting to `gfx1150` — so a Halo host running only `llamacpp:rocm` never set it and got no warning, exactly the host the message claimed to protect. `gpuTarget` is the host's real-chip signal; `vllmGpuTarget` now defaults to it. The trigger is an OR across both so existing configs that only set `vllmGpuTarget` keep warning.

Verified by eval matrix: gfx1151+old kernel with vLLM off → warns (previously silent); gfx1151+old+vLLM on → warns; legacy `vllmGpuTarget`-only config → warns; gfx1150 → silent; gfx1151+current kernel → silent.

## README: image-gen smoke test logged the wrong backend

The README claimed `backend: rocm`. It is `backend: vulkan` — `vulkan` precedes `rocm` in the descriptor support tables, and because the module wires `*_bin` for both variants, both report `installed`, so the not-installed tie-break never fires and Vulkan wins.

This was already wrong before the version bump: ca774cd (#60) stated lemond routes sd-cpp to Vulkan while lemonade was still pinned at 11.0.0, but the expected-log line was never updated. 11.5.1 only formalized it upstream. The override now documented is `lemonade.settings.sdcpp.backend` — the config section is `sdcpp`, not `sd-cpp`.

The other two 11.5.1 breaking changes (model-id field, prefixed collection ids) were checked against `pkgs/benchmark-go` and `scripts/` and need no changes.

## Verification

Full `nix flake check` green, including `lemond-vm`. New checks: `module-eval-lemonade-allowed-origins`, and `module-eval-cwsr-warning` covering all five rows above. `lemond-unit-render` gained a negative control asserting `LEMONADE_ALLOWED_ORIGINS` stays unset when no origins are listed — confirmed non-vacuous by injecting a value and watching it fail.

## Note on branch structure

The component branches are pushed (`fix/78-lemonade-allowed-origins`, `feat/gfx1151-cwsr-kernel-guard`, `docs/lemonade-11-5-x-behaviour-changes`, `fix/cwsr-warning-trigger-scope`) but are not separately mergeable: the first two both add a `warnings` attribute at the same point, and two `warnings` attributes in one attrset is an eval error. The collision resolution lives only here.
