### PR TITLE
docs(eval): land TheRock ROCm vs Vulkan gfx1150 evaluation results

### DIFF
--- a/docs/superpowers/plans/2026-07-21-therock-rocm-evaluation.md
+++ b/docs/superpowers/plans/2026-07-21-therock-rocm-evaluation.md
@@ -1,0 +1,223 @@
+# TheRock ROCm — Phase 0 Evaluation Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Produce a documented, GPU-validated A/B benchmark of **Vulkan vs up-to-date TheRock ROCm** for llama.cpp (and, if cheap, stable-diffusion.cpp) on Strix Halo-class hardware, so the go/no-go on vendoring TheRock is decided by data — not the premise that "newer ROCm must be better."
+
+**Architecture:** Reuse the repo's existing `pkgs/benchmark-go` harness and `llama-bench` for measurement; get a TheRock-ROCm backend for the eval via the community flakes as a **throwaway bridge** (no in-repo vendoring commitment). Hold the kernel constant at a known-good gfx1151 version. Two tracks: a gfx1150 bring-up/methodology track runnable now, and the decisive gfx1151 track gated on the incoming hardware.
+
+**Tech Stack:** Nix flakes, `llama-bench` (from `llama-cpp-vulkan` / TheRock llama), `pkgs/benchmark-go` (`.#benchmark`), `amdgpu_top` / `rocminfo` for GPU-utilisation validation, `demyanrogozhin/nix-llama-rocm` + `hellas-ai/nix-strix-halo` as build cookbooks.
+
+**Spec:** `docs/superpowers/specs/2026-07-21-therock-rocm-design.md` (Phase 0 section).
+
+---
+
+## Notes for the executor
+
+- This is an **evaluation spike**, not feature code. "Tests" here are **validity gates**: every ROCm/Vulkan number is worthless unless you prove the GPU (not CPU) actually ran the work. The repo's harness already has a silent-CPU-fallback guardrail (`pkgs/benchmark-go/internal/preflight`) — use it, and cross-check with `amdgpu_top`.
+- **Do not add community flakes as permanent inputs to this repo's `flake.nix`.** Build them out-of-tree via `nix build github:...#attr` or a scratch flake under the scratchpad. The repo's `flake.lock` stays clean until (and unless) the go decision is "vendor."
+- Record every number in `docs/therock-eval-results.md` (created in Task 1). Commit results as you go.
+- Hold the model files constant across backends (same GGUF, same quant) or the A/B is meaningless.
+
+---
+
+## Task 1: Lock the Vulkan baseline on gfx1150 + create the results doc
+
+**Files:**
+- Create: `docs/therock-eval-results.md`
+
+- [ ] **Step 1: Build the Vulkan llama-bench and confirm the GPU is visible**
+
+Run:
+```bash
+cd ~/git/noamsto/nix-amd-ai-worktrees/feat-therock-rocm
+VULKAN_LLAMA=$(nix build --no-link --print-out-paths .#llama-cpp-vulkan)
+"$VULKAN_LLAMA/bin/llama-bench" --help >/dev/null && echo "llama-bench OK"
+rocminfo 2>/dev/null | grep -E 'Name: *gfx' | head -1   # expect gfx1150 on this host
+```
+Expected: `llama-bench OK` and a `gfx1150` line.
+
+- [ ] **Step 2: Run the Vulkan baseline on the two README models**
+
+Pick a model already in the HF cache (reuse the repo's benchmark model set). Run, for each model GGUF path `$M`:
+```bash
+"$VULKAN_LLAMA/bin/llama-bench" -m "$M" -ngl 999 -p 256 -n 128 -r 3 -o md
+```
+Expected: a markdown table with non-trivial `pp`/`tg` t/s. Capture the exact numbers.
+
+- [ ] **Step 3: Validity gate — prove Vulkan used the GPU**
+
+In a second shell during the run:
+```bash
+# NOTE: `-d` is a one-shot device-info dump, NOT sampling. For a busy% time series use JSON sampling:
+# amdgpu_top -J -n <iters> -s <ms>  and read devices[0].gpu_activity.GFX
+amdgpu_top -J -n 20 -s 150 2>/dev/null | jq '.devices[0].gpu_activity.GFX'   # GPU busy % should climb well above idle
+```
+Expected: GPU utilisation rises during the bench (not ~0 with CPU pegged). If the GPU stays idle, the run is invalid — stop and fix `-ngl`/device selection before recording.
+
+- [ ] **Step 4: Record baseline + methodology**
+
+Create `docs/therock-eval-results.md` with: host arch (gfx1150), kernel version (`uname -r`), llama.cpp build number, exact model files + quant, the Vulkan `pp`/`tg` numbers, and the GPU-utilisation evidence. This is the fixed "A" side of every later A/B.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add docs/therock-eval-results.md
+git commit -m "docs(eval): lock gfx1150 Vulkan llama.cpp baseline + methodology"
+```
+
+---
+
+## Task 2: Cheap preliminary probe — TheRock ROCm *runtime* under the existing stack (gfx1150)
+
+Goal: a fast, zero-build signal for whether the *newer ROCm runtime* moves llama.cpp perf on gfx1150, before investing in a faithful TheRock build. **Caveat to record loudly:** this runs the *nixpkgs-compiled* `llama-server` on the *TheRock ROCm runtime* (same sonames, shadowed via `LD_LIBRARY_PATH`) — it is an ABI-mixed probe, not a faithful "TheRock-built llama.cpp" test. Treat it as directional only.
+
+**Files:** none in-repo (scratch only).
+
+- [ ] **Step 1: Obtain the TheRock gfx1150 runtime libs**
+
+Reuse the SDK tarball lemonade already knows how to fetch (`therock-dist-linux-gfx1150-*`), or the copy under a lemonade cache if present. Unpack to a scratch dir `$THEROCK/lib`. Confirm it carries `libamdhip64.so.7`, `librocblas.so.5`, `libhipblas.so.3`.
+
+- [ ] **Step 2: Run llama-bench with the TheRock runtime shadowing the nix ROCm libs**
+
+Build the nix ROCm llama-bench, then run it with TheRock libs + `libatomic` (the #57 dep) prepended:
+```bash
+ROCM_LLAMA=$(nix build --no-link --print-out-paths .#llama-cpp-rocm)
+LIBATOMIC=$(dirname $(nix eval --raw nixpkgs#gcc.cc.lib)/lib/libatomic.so.1 2>/dev/null || echo /nix/store)  # resolve libatomic dir
+LD_LIBRARY_PATH="$THEROCK/lib:$LIBATOMIC" "$ROCM_LLAMA/bin/llama-bench" -m "$M" -ngl 999 -p 256 -n 128 -r 3 -o md
+```
+Expected: it runs (no exit 127 — libatomic present) and reports `pp`/`tg`. If it faults/crashes, record that as a signal (ABI mismatch between nix-ggml-hip and TheRock runtime) and move to the faithful build in Task 3.
+
+- [ ] **Step 3: Validity gate + record**
+
+Confirm GPU used (`amdgpu_top`). Append to `docs/therock-eval-results.md` under a clearly-labelled "PRELIMINARY / ABI-mixed probe (directional only)" heading, next to the Vulkan baseline.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add docs/therock-eval-results.md
+git commit -m "docs(eval): preliminary ABI-mixed TheRock-runtime probe on gfx1150"
+```
+
+---
+
+## Task 3: Faithful TheRock-built llama.cpp for gfx1150 (the real bring-up + B3 de-risk)
+
+Goal: build llama.cpp actually compiled against the TheRock SDK for gfx1150, using `demyanrogozhin/nix-llama-rocm` as the cookbook. This is the spike that answers spec open-question B3 (does an in-sandbox `hipcc` + bitcode path work).
+
+**Files:**
+- Create: `<scratchpad>/therock-eval/flake.nix` (throwaway; NOT in the repo)
+- Create: `<scratchpad>/therock-eval/rocm-sources.json` (adds a `gfx1150` pin)
+
+- [ ] **Step 1: Find the TheRock gfx1150 nightly tarball URL + hash**
+
+```bash
+# demyanrogozhin's update script shows the bucket + naming; adapt for gfx1150
+gh api repos/demyanrogozhin/nix-llama-rocm/contents/update-rocm.py --jq '.content' | base64 -d | grep -iE 'therock|s3|gfx|url' | head
+# then resolve the gfx1150 asset:
+nix store prefetch-file --json "https://therock-nightly-tarball.s3.amazonaws.com/therock-dist-linux-gfx1150-<VER>.tar.gz" | jq '{hash,storePath}'
+```
+Expected: a valid `sha256` for a `gfx1150` tarball (lemonade already pulled `gfx1150-7.13.0`, so one exists — pin whatever current nightly resolves).
+
+- [ ] **Step 2: Vendor demyanrogozhin's derivations into a scratch flake with a gfx1150 target**
+
+In `<scratchpad>/therock-eval/`, write a flake that (a) takes `demyanrogozhin/nix-llama-rocm` as an input, (b) overrides its `rocm-sources.json` to add the `gfx1150` entry from Step 1, and (c) exposes `llama-cpp-gfx1150`. Crib the exact override from their `pkgs/llamacpp-rocm.nix` + `pkgs/rocm7-bin.nix`.
+
+- [ ] **Step 3: Build it — this is the B3 spike**
+
+```bash
+nix build ~/.../scratchpad/therock-eval#llama-cpp-gfx1150 2>&1 | tee build.log
+```
+Expected: SUCCESS. If it fails on `hipcc`/device-lib/bitcode resolution in the sandbox, capture the exact error — that failure *is* a key Phase-0 finding (it quantifies the vendoring cost). Record it either way.
+
+- [ ] **Step 4: Benchmark the faithful TheRock-built llama vs Vulkan**
+
+```bash
+THEROCK_LLAMA=<scratch build out path>
+"$THEROCK_LLAMA/bin/llama-bench" -m "$M" -ngl 999 -p 256 -n 128 -r 3 -o md
+```
+Same models, same flags as Task 1. Validity-gate with `amdgpu_top`.
+
+- [ ] **Step 5: Record the faithful gfx1150 A/B**
+
+Append to `docs/therock-eval-results.md`: faithful TheRock-built numbers vs the Vulkan baseline, the build effort/patches needed (B3 evidence), and whether TheRock changed the gfx1150 verdict.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add docs/therock-eval-results.md
+git commit -m "docs(eval): faithful TheRock-built llama.cpp A/B on gfx1150 + B3 spike notes"
+```
+
+---
+
+## Task 4: Preliminary decision checkpoint (gfx1150 data)
+
+**Files:**
+- Modify: `docs/therock-eval-results.md`
+
+- [ ] **Step 1: Summarise the gfx1150 signal**
+
+Write a "gfx1150 preliminary verdict" section: did faithful TheRock ROCm beat Vulkan on decode/prefill? By how much? How hard was the build (B3)? Note that gfx1150 is *not* decisive (both backends work here; the driver is gfx1151), so this only sizes the effort and gives an early lean.
+
+- [ ] **Step 2: Commit + surface to maintainer**
+
+```bash
+git add docs/therock-eval-results.md
+git commit -m "docs(eval): gfx1150 preliminary verdict"
+```
+Then stop and report the gfx1150 numbers + B3 build cost to the maintainer before the gfx1151 hardware work.
+
+---
+
+## Task 5: Decisive gfx1151 protocol (GATED on the incoming Strix Halo)
+
+Do not start until the gfx1151 machine is in hand. This is the run that actually decides.
+
+**METHODOLOGY CORRECTION (from community gfx1151 data — see `docs/therock-eval-results.md` "Community gfx1151 data" section):** the gfx1150 run measured ROCm's *worst* case (short ctx, plain HIP). On gfx1151, ROCm's win is at **long context with a fully-optimized build**. So Task 5 MUST:
+- Bench at **long context (8K / 16K / 32K)**, not just pp512/tg128. Report pp and tg at each length — the crossover is the whole point (Vulkan decode collapses ~32 t/s @ 8K while HIP+rocWMMA holds ~51 t/s).
+- Build the ROCm/HIP side **fully optimized: rocWMMA ON + Flash-Attention + hipBLASLt** (not plain HIP). Use TheRock ROCm (nixpkgs 7.2.3 faults on gfx1151). Vulkan side keeps `-fa` too.
+- Frame the go/no-go around the **coding-agent (long-context) regime**, which is the actual reason for Strix Halo — not short-context chat.
+
+**Files:**
+- Modify: `docs/therock-eval-results.md`
+- Modify (only if go): `README.md` (kernel recommendation)
+
+- [ ] **Step 1: Pin the known-good gfx1151 kernel**
+
+Boot a kernel in the validated gfx1151 range (currently ~6.18.6–6.18.14; **avoid 6.19.x** which misIDs gfx1151 as gfx1100). Record `uname -r` and confirm `rocminfo` reports `gfx1151` (not `gfx1100`, and without needing `HSA_OVERRIDE_GFX_VERSION`). Hold this kernel constant for both backends.
+
+- [ ] **Step 2: Vulkan baseline on gfx1151**
+
+Repeat Task 1 steps 2–3 on gfx1151. Record. (This also confirms RADV/Vulkan works on gfx1151, the cheap-path hypothesis.)
+
+- [ ] **Step 3: TheRock-built llama on gfx1151**
+
+Use `demyanrogozhin`/`hellas-ai`'s **gfx1151** target directly (it's their primary target — no gfx1150 hacking needed): `nix build github:demyanrogozhin/nix-llama-rocm#<gfx1151 llama attr>`. Benchmark, validity-gate.
+
+- [ ] **Step 4: (If cheap) sd-cpp Vulkan-vs-ROCm on gfx1151**
+
+Check whether a Vulkan `stable-diffusion.cpp` exists/builds; if so, A/B images-per-second Vulkan-sd vs TheRock-ROCm-sd. This is the likeliest ROCm win.
+
+- [ ] **Step 5: Record the decisive A/B + apply the go/no-go gate**
+
+Append gfx1151 numbers. Apply the spec's decision gate:
+- **TheRock clearly wins** on a backend that matters → GO: proceed to the contingent Integration plan (write it next, folding in critic fixes B1/B3/B4/B5).
+- **Vulkan wins/ties** → NO-GO: Vulkan-first; keep nixpkgs ROCm as fallback/tooling; shelve the vendor. Document so it isn't re-litigated.
+
+- [ ] **Step 6: Update the gfx1151 kernel recommendation (regardless of go/no-go)**
+
+Add a README note recommending the validated known-good gfx1151 kernel for Strix Halo hosts (a per-host note — do NOT bump the global `>= 6.14` NPU assertion). Commit.
+
+```bash
+git add docs/therock-eval-results.md README.md
+git commit -m "docs(eval): decisive gfx1151 A/B + verdict; README gfx1151 kernel note"
+```
+
+---
+
+## Self-review (done by plan author)
+
+- **Spec coverage:** Phase 0 "what to measure" → Tasks 1–5; "how to get a TheRock backend cheaply" → Tasks 2 (probe) + 3/5 (faithful, via community bridge, no repo input); "kernel controlled variable + deliverable" → Task 5 steps 1 & 6; "decision gate" → Tasks 4 & 5.5; B3 spike → Task 3.3; sd-cpp secondary → Task 5.4. Integration (Phase 1+) is intentionally out of this plan — it's contingent and gets its own plan on GO.
+- **No placeholders:** commands are concrete; the two genuinely-unknown values (gfx1150 tarball hash, exact model GGUF paths) are resolved *by an explicit command in-step*, not hand-waved.
+- **Consistency:** results doc `docs/therock-eval-results.md` created in Task 1, appended in 2/3/4/5; validity gate (`amdgpu_top`) applied uniformly.

--- a/docs/superpowers/specs/2026-07-21-therock-rocm-design.md
+++ b/docs/superpowers/specs/2026-07-21-therock-rocm-design.md
@@ -1,0 +1,89 @@
+# TheRock ROCm — evaluate, then (maybe) integrate
+
+**Status:** approved design (evaluation-first), pre-plan
+**Date:** 2026-07-21
+**Goal:** the best inference experience on Strix Halo (gfx1151). Determine *with data* whether up-to-date ROCm (via AMD "TheRock") beats the flake's current Vulkan path — and only vendor TheRock if it earns its keep.
+
+## Why this is evaluation-first (not integrate-first)
+
+The flake's own README benchmarks (gfx1150) recommend **Vulkan** for general LLM inference: Vulkan wins decode at every size tested (+26% on Gemma-26B tg128) and ties/wins prefill; ROCm is "kept as a fallback and for ecosystem tooling." whisper already runs Vulkan; RADV/Vulkan is arch-agnostic and works on gfx1151.
+
+**But that data is Vulkan vs *nixpkgs ROCm 7.2.3*** — the old runtime with known gfx1151 VRAM faults. The open question is whether **up-to-date TheRock ROCm (native gfx1151 kernels)** changes that verdict. Nobody has that A/B. Vendoring a whole per-arch SDK + rebuilding backends is a large, ongoing, solo-maintained cost (see "Integration cost" below); we do not pay it on an unmeasured premise.
+
+So: **measure first (Phase 0). Integrate only if TheRock ROCm meaningfully beats Vulkan on the backend that matters.**
+
+## Hard constraint (verified)
+
+TheRock is a **monolithic prebuilt SDK tarball, per gfx arch** (`therock-dist-linux-gfx1151-7.11.0aNNNN.tar.gz`), from a fast-moving nightly S3 bucket. Not shaped like nixpkgs `rocmPackages`. Consequences: no drop-in override; each backend must be **rebuilt against the SDK** (needs the SDK's `hipcc`/clang/comgr **at build time in the sandbox**, not just runtime `.so`s); per-arch builds (gfx1150 + gfx1151). Packaging the SDK's *runtime libs* is easy (`fetchurl` + `autoPatchelfHook`); getting its *compiler toolchain* to run in the nix sandbox is the real risk (Phase-1 spike). Community precedent: `demyanrogozhin/nix-llama-rocm`, `hellas-ai/nix-strix-halo` — both rebuild backends against the SDK.
+
+---
+
+## Phase 0 — Evaluation (the immediate work)
+
+**Deliverable:** a documented A/B benchmark of **Vulkan vs TheRock ROCm** for the candidate backends, on real hardware, using the repo's existing `pkgs/benchmark-go` harness (`.#benchmark`). Output feeds the go/no-go decision below.
+
+### What to measure
+- **llama.cpp**: decode (tg) + prefill (pp) across the README's model sizes (Gemma-26B, Qwen3.5-9B), Vulkan vs TheRock ROCm. Power/thermal if cheap (ryzenadj/amdgpu_top, as the harness already surfaces).
+- **stable-diffusion.cpp** (secondary): is there a viable **Vulkan sd-cpp** path at all? If yes, Vulkan-sd vs TheRock-ROCm-sd images/sec. (Image gen is the likeliest place ROCm still wins, since llama already favours Vulkan.)
+
+### Hardware
+- **gfx1150 (this P14s, now):** Vulkan vs TheRock-ROCm-7.1x. Informative even though README shows Vulkan beats *old* ROCm here — the question is whether *new* ROCm closes/reverses the gap.
+- **gfx1151 (incoming Strix Halo):** the real target. Re-run when hardware lands. This is where old ROCm is broken, so it's the decisive A/B.
+
+### Kernel is a controlled variable (and a deliverable)
+The repo's only kernel guidance today is a **`>= 6.14` floor driven by the NPU (`amdxdna`)** (README:114, hard assertion `modules/amd-npu.nix:217`) — there is **no gfx1151-GPU-tuned recommendation**. Real-world Strix Halo guidance clusters at **Linux 6.18.4+** (RDNA3.5 patches merged), with **6.19.x misidentifying gfx1151 as gfx1100** (needs `HSA_OVERRIDE_GFX_VERSION`) — so newer ≠ better. Therefore:
+- The A/B must **hold the kernel constant at a known-good gfx1151 version**, or the Vulkan-vs-ROCm result is confounded.
+- Phase 0 output includes the **validated known-good gfx1151 kernel** (for both Vulkan and TheRock ROCm), fed back into a **README gfx1151 kernel recommendation** (a per-host note, *not* a global assertion bump — the 6.14 floor stays correct for gfx1150 / Hawk Point).
+
+### How to get a TheRock-ROCm backend *cheaply* for the eval (no vendoring commitment)
+Use the community flakes as a **bridge/cookbook**, not a dependency: build a throwaway TheRock-ROCm `llama-server` (and sd `sd-server` if feasible) from `demyanrogozhin/nix-llama-rocm` or `hellas-ai/nix-strix-halo` (adding a gfx1150 target/pin if their set omits it), and point the benchmark harness at it. This avoids paying the vendoring cost before the data justifies it. (The critic explicitly endorses hellas-ai as a legitimate short-term bridge / reference.)
+
+### Decision gate (end of Phase 0)
+Split by **context regime** (community gfx1151 data shows the answer flips with context length — short: Vulkan; long/agentic: optimized ROCm+rocWMMA):
+- **Long-context (8K–32K+, the coding-agent regime):** if optimized **TheRock ROCm + rocWMMA + FA + hipBLASLt** holds decode where Vulkan collapses (community shows ~51 vs ~32 t/s @ 8K) → **GO** for a per-arch (gfx1151-only) rocWMMA ROCm llama path → Integration (below) + critic fixes.
+- **Short-context / image-gen / whisper:** **Vulkan-first** — keep llama-short + whisper on Vulkan, add a Vulkan sd-cpp (independently worth doing now — image-gen isn't long-token-decode), keep nixpkgs ROCm as fallback/tooling.
+- The realistic outcome is likely **both**: Vulkan for short-ctx + image-gen, an optimized-ROCm gfx1151 path for long-ctx LLM. gfx1150 stays Vulkan (rocWMMA regressed there). Document the numbers either way.
+
+---
+
+## Integration (Phase 1+) — CONTINGENT on Phase 0
+
+Only if Phase 0 says TheRock wins. Approach: **vendor TheRock in-repo, deliberately pinned, phased by the winning backend first, in a separate hand-gated update lane, with nixpkgs ROCm kept as a live fallback.** Rejected: consuming `hellas-ai` as a runtime flake *input* (couples reproducibility + Cachix to a third party; use as cookbook only).
+
+### The auto-merge safety hole (core maintainability principle)
+Today auto-merge is safe because a green build ⇒ a nixpkgs-*vetted* working ROCm. Building against TheRock breaks that proxy: nightlies compile clean and then fault on hardware, and CI has **no gfx1151 GPU**. So the TheRock lane cannot auto-merge; it must be **quarantined** so it can't contaminate the working nixpkgs lane.
+
+### Architecture (contingent)
+1. **SDK package** `pkgs/rocm-therock/`: `fetchurl` + `autoPatchelfHook`, parameterised per gfx target; `rocm-sources.json` = `{url,sha256,version}` per arch (`gfx1150`,`gfx1151`). Model on demyanrogozhin's `rocm7-bin.nix`.
+2. **Backends rebuilt against the SDK**, winning backend first (per Phase 0). Custom derivation with cmake → SDK; **explicit spike: does autoPatchelf yield a working in-sandbox `hipcc`, and do device-lib/bitcode (`amdgcn`) paths resolve** (B3). Crib patches from the community flakes.
+3. **Module rework (NOT "unchanged" — B1).** `modules/amd-npu.nix` hardcodes nixpkgs ROCm in ≥4 places: `ldLibraryPath` (`rocmPackages.clr`), `LEMONADE_GGML_HIP_PATH` (×2), the `llamacpp-rocm` symlink source, and `systemPackages` clr. The lemond service sets a **service-wide `LD_LIBRARY_PATH` with nixpkgs clr 7.2.3**; a TheRock `llama-server` subprocess would inherit it and load the old (faulting) ROCm ahead of its own RPATH — the exact #57 shadowing class. Phase 1 must: make the ROCm provider selectable, key `LD_LIBRARY_PATH` / `LEMONADE_GGML_HIP_PATH` / `systemPackages` clr to the selected provider, and **isolate a TheRock backend from the nixpkgs ROCm libs still used by sd-cpp/whisper in the same service**.
+4. **Per-arch + fallback.** Expose per-arch TheRock backends; a **module option selects provider, defaulting to `nixpkgs`** so existing hosts' eval is unchanged (back-compat). Keep nixpkgs `llama-cpp-rocm` alive as fallback — **note: on gfx1151 the nixpkgs fallback is the faulting 7.2.3, so it's a gfx1150-safe fallback only**, and keeping both providers ~doubles CI build + Cachix surface (not free).
+5. **#57 interaction:** the `will_install_therock → false` patch (PR #59) stays — it stops lemonade's *runtime* download; our vendored SDK is a *build-time* dep. Complementary.
+
+### Update automation (contingent)
+- **Deliberate pins, never weekly-auto.** Pin a chosen TheRock build (release/branch tag if usable — open question; else a hand-picked nightly), bump a few times/quarter.
+- **Split lanes with real edits (B4).** There is **no** generic tricky-bump facility — `update.yml` auto-merge is hardcoded to `mtp_override_needs_update != 'true'`. Adding TheRock means concrete edits to `check-updates.sh` (detect TheRock updates) and the auto-merge `if:` (exclude the TheRock lane). Do not describe this as "reusing an existing mechanism."
+- **Smoke gate must be real or labelled unenforced (B4).** A "manual checkbox" is enforced by nothing without branch protection + a named required status check. Either stand up a self-hosted gfx1150/gfx1151 runner emitting a required check, **or** downgrade to "maintainer-discipline checklist, unenforced — accepted risk" and say so. No hand-waving.
+
+### License / Cachix (B5 — gate before any public caching)
+Before pushing TheRock-derived outputs to public `nix-amd-ai.cachix.org`: **confirm AMD/TheRock redistribution terms permit it** (ROCm is largely MIT/NCSA so likely OK, but bundles may carry closed bits — verify). Quantify added per-arch closure/cache size and CI build-time delta (these outputs are **not** Hydra-cached, unlike today's `pkgs.llama-cpp-rocm`). Option: cache only the `fetchurl` FOD, not the derived toolchain. **License is a hard blocker for public caching; not a blocker for Phase 0 (local).**
+
+---
+
+## Open questions (resolve at the integration gate, not Phase 0)
+1. TheRock usable release/branch tags vs curated nightlies (pin discipline).
+2. Backend build recipe against the SDK; in-sandbox `hipcc` + bitcode resolution (the B3 spike).
+3. Per-arch selection UX (explicit option vs auto-detect); confirmed default = `nixpkgs`.
+4. Smoke-test runner: self-hosted GH runner vs unenforced checklist.
+5. gfx1150 SDK bundle exact tarball name (lemonade already pulled `gfx1150-7.13.0`, so it exists).
+6. AMD redistribution license for public Cachix (B5).
+
+## Out of scope
+- Making the TheRock path auto-merge (rejected).
+- vLLM / PyTorch / Python-wheel stack.
+- Replacing nixpkgs ROCm for anything beyond the named backends.
+
+## Related
+- #57 / PR #59 (lemonade runtime TheRock-download fix) — complementary; the `libatomic` shadowing there is the same bug class as B1.
+- Memory: incoming-strix-halo-128gb, upstream-versions-to-watch, perf-baselines-gfx1150, bench-ciru-ai (RADV/Vulkan on gfx1151), rocwmma-build-flag (rocWMMA regressed on gfx1150 — re-test per arch), mtp-ab-benchmark (harness methodology).
+- Cookbook refs: `demyanrogozhin/nix-llama-rocm`, `hellas-ai/nix-strix-halo`.

--- a/docs/therock-eval-results.md
+++ b/docs/therock-eval-results.md
@@ -1,0 +1,314 @@
+# Vulkan vs TheRock ROCm eval — gfx1150
+
+Evaluating whether to vendor an up-to-date TheRock ROCm build for llama.cpp on
+this host, against the current Vulkan backend. This doc locks the **Vulkan
+baseline ("A" column)** first; a TheRock ROCm "B" column gets added
+alongside it once that build exists.
+
+**Result: Vulkan wins on both models, both metrics.** TheRock ROCm 7.13.0 is
+3-5% slower on prompt processing and 10-11% slower on token generation than
+the Vulkan (RADV) backend on this gfx1150 host. See "TheRock ROCm build" and
+"Results" below for the full numbers and the B3 build-effort verdict.
+
+## Host
+
+- Arch: **gfx1150** (AMD Radeon 890M, Strix Point APU)
+- Kernel: `uname -r` → `7.1.3`
+- RAM: 54 GiB total (UMA, no dedicated VRAM)
+- `rocminfo | grep 'Name: *gfx'` → `gfx1150`
+
+## Build under test
+
+- Package: `.#llama-cpp-vulkan` (built via `nix build --no-link --print-out-paths .#llama-cpp-vulkan`)
+- Store path: `/nix/store/mqq37s52wv4z59wa4g5gccij5iacjawp-llama-cpp-9608`
+- llama.cpp build (from `llama-bench` banner): `build: 70b54e1 (9608)`
+- Vulkan device reported by llama-bench: `AMD Radeon 890M Graphics (RADV STRIX1) (radv) | uma: 1 | fp16: dot2 | bf16: 0 | warp size: 64 | shared memory: 65536 | int dot: 1 | matrix cores: KHR_coopmat`
+
+## TheRock ROCm build
+
+- SDK: TheRock prebuilt `gfx1150-7.13.0` (ROCm **7.13.0**, `hipconfig --version` →
+  `7.13.99004-3309c6114a`), downloaded via lemonade's TheRock fetch path.
+  Fetch speed from the S3 bucket: **~350 KB/s** — a 16 GB SDK takes on the
+  order of hours to pull cold. This is a real maintenance/CI cost to note if
+  vendoring TheRock: re-fetching on cache miss is slow regardless of build
+  effort.
+- llama.cpp source: same nixpkgs-pinned source as the Vulkan build
+  (`nix eval --raw .#llama-cpp-vulkan.src`, using the flake's own pinned
+  nixpkgs — the system's default nixpkgs channel resolves to a *different*,
+  newer llama.cpp (9925) and must not be used for this comparison). The
+  source's `COMMIT` file reads `70b54e1`, confirming it's the exact same
+  commit as the Vulkan baseline's `build: 70b54e1 (9608)`. Because the
+  copied source tree has no `.git`, the compiled binary's own build banner
+  prints `build: unknown (0)` instead of `9608` — the `COMMIT` file is the
+  authoritative confirmation of version match, not the runtime banner.
+- Build command matched build 9608 exactly in source; only the backend
+  (`GGML_HIP=ON`, `AMDGPU_TARGETS=gfx1150`) differs from the Vulkan build.
+
+### B3 build-effort verdict: **hard, but tractable in one focused session (~2 hours)**
+
+Getting `llama-bench` to link and run against the SDK's `amdclang++` required
+four non-obvious fixes, none of which are documented anywhere in TheRock's
+or llama.cpp's build docs for a NixOS host:
+
+1. **`libatomic.so.1` missing** (known from a prior investigation — see repo
+   notes): TheRock's runtime libs need it and NixOS doesn't ship it by
+   default. Pulled from `nixpkgs#gcc.cc.lib` and put on `LD_LIBRARY_PATH`.
+2. **`amdclang++` can't find a C++ standard library on NixOS** — there's no
+   `/usr/include` or `/usr/lib` for it to fall back to. Fixed with
+   `--gcc-toolchain=<nixpkgs gcc unwrapped store path>` (finds `cstdlib`/
+   `cmath` from GCC's bundled C++ headers) plus `-idirafter <glibc.dev>/include`
+   (supplies `math.h` etc. — must be `-idirafter`, not `-isystem`, because
+   `#include_next` in GCC's `<cmath>` needs the glibc headers to sit *after*
+   GCC's own C++ headers in the search list, and `-isystem` inserts too early).
+3. **Linking fails**: `ld.lld` (bundled with the SDK) can't find `Scrt1.o`,
+   `crti.o`/`crtn.o`, `-lstdc++`, `-lgcc_s`, `-lc` because none of nixpkgs'
+   gcc/glibc paths are on its default search path. Fixed with
+   `-B <glibc>/lib -L <glibc>/lib -L <gcc.cc.lib>/lib -Wl,-dynamic-linker,<glibc>/lib/ld-linux-x86-64.so.2`.
+4. **The real trap**: CMake's own HIP-compiler-identification probe (which
+   determines `CMAKE_HIP_COMPILER_ID`) does its own private compile+link
+   using only `CMAKE_HIP_FLAGS` — it does **not** pick up
+   `CMAKE_EXE_LINKER_FLAGS`. With the linker flags only set on
+   `CMAKE_EXE_LINKER_FLAGS`, the identification probe's link step failed
+   silently, `CMAKE_HIP_COMPILER_ID` came back empty, and CMake then
+   generated build rules that omitted `-x hip` on `.cu` files (ggml marks
+   its CUDA-shaped `.cu` sources as `LANGUAGE HIP` via
+   `set_source_files_properties`, but relies on Clang-HIP CMake module
+   detection to add `-x hip`). The symptom was a confusing, unrelated-looking
+   error: `clang++: error: unsupported CUDA gpu architecture: gfx1150`
+   (clang silently fell back to CUDA-mode compilation without `-x hip`, then
+   rejected `gfx1150` as an invalid `sm_XX` CUDA arch). Fix: fold the linker
+   flags into `CMAKE_HIP_FLAGS` itself, not just `CMAKE_EXE_LINKER_FLAGS`, so
+   the identification probe's link step succeeds too.
+
+Once those four fixes were in place, the actual `llama-bench` HIP target
+built cleanly with `ninja` in one pass (~378 targets, few minutes). The
+final working `cmake` configure line:
+
+```bash
+cmake -S <src> -B build -G Ninja \
+  -DGGML_HIP=ON -DAMDGPU_TARGETS=gfx1150 -DCMAKE_BUILD_TYPE=Release \
+  -DCMAKE_HIP_COMPILER=<SDK>/bin/amdclang++ \
+  -DCMAKE_PREFIX_PATH=<SDK> \
+  -DCMAKE_HIP_FLAGS="--rocm-path=<SDK> --gcc-toolchain=<gcc-unwrapped> -idirafter <glibc.dev>/include -B <glibc>/lib -L <glibc>/lib -L <gcc.cc.lib>/lib -Wl,-dynamic-linker,<glibc>/lib/ld-linux-x86-64.so.2" \
+  -DCMAKE_EXE_LINKER_FLAGS="-B <glibc>/lib -L <glibc>/lib -L <gcc.cc.lib>/lib -Wl,-dynamic-linker,<glibc>/lib/ld-linux-x86-64.so.2" \
+  -DCMAKE_SHARED_LINKER_FLAGS="<same as above>" \
+  -DCMAKE_MODULE_LINKER_FLAGS="<same as above>" \
+  -DLLAMA_CURL=OFF -DLLAMA_BUILD_TESTS=OFF -DLLAMA_BUILD_EXAMPLES=ON
+```
+
+None of this is exotic once found, but every one of the four failures
+produced a misleading or generic error message (`cmath` not found,
+`unable to find library -lstdc++`, and — worst — the `unsupported CUDA gpu
+architecture` red herring), so getting from "TheRock SDK on disk" to "GPU
+executing HIP kernels" took real debugging, not just following a recipe.
+Vendoring this into the flake would mean baking all of the above into a
+Nix derivation (a `--gcc-toolchain`/glibc-path-aware wrapper around
+`amdclang++`, essentially reimplementing part of what nixpkgs' own
+`rocmPackages` wrapper already does) — moderate ongoing maintenance cost,
+not a one-off patch.
+
+## Methodology
+
+Standard bench matching the README's existing numbers (prompt 256 / gen 128, 3
+reps after warmup, `-ngl 999` to force full GPU offload):
+
+```bash
+<out>/bin/llama-bench -m "<MODEL>" -ngl 999 -p 256 -n 128 -r 3 -o md
+```
+
+Two models, picked to bracket size/architecture:
+
+| Size  | Model | Exact path | Quant |
+| ----- | ----- | ---------- | ----- |
+| Large (MoE) | `unsloth/gemma-4-26B-A4B-it-GGUF` (README's model) | `/home/noams/.cache/huggingface/hub/models--unsloth--gemma-4-26B-A4B-it-GGUF/snapshots/8bacec5c8e829a25502cdfe3c3f5b6aabee3218c/gemma-4-26B-A4B-it-UD-Q4_K_M.gguf` | UD-Q4_K_M |
+| Small (dense) | `unsloth/Qwen3-8B-GGUF` | `/home/noams/.cache/huggingface/hub/models--unsloth--Qwen3-8B-GGUF/snapshots/a6adef130ffb23ddaf1a62fec9dced968c9bc482/Qwen3-8B-Q8_0.gguf` | Q8_0 |
+
+## Results
+
+| Model | Params | Backend | pp256 t/s | tg128 t/s | TheRock ROCm pp256 t/s | TheRock ROCm tg128 t/s |
+| ----- | ------ | ------- | --------: | --------: | ---------------------: | ---------------------: |
+| gemma4 26B.A4B Q4_K - Medium | 25.23 B | **Vulkan (baseline)** | 326.38 ± 1.58 | 19.67 ± 0.09 | 310.42 ± 6.31 (**-4.9%**) | 17.57 ± 0.34 (**-10.7%**) |
+| qwen3 8B Q8_0 | 8.19 B | **Vulkan (baseline)** | 461.13 ± 5.21 | 9.46 ± 0.01 | 445.80 ± 7.12 (**-3.3%**) | 8.51 ± 0.11 (**-10.0%**) |
+
+**Vulkan (RADV) beats TheRock ROCm 7.13.0 on every metric, both models.**
+The gap is small on prompt processing (3-5% slower) but consistent and
+larger on token generation (10-11% slower). Percentages are TheRock relative
+to the Vulkan baseline (negative = TheRock slower).
+
+Full raw `llama-bench -o md` output per model:
+
+**gemma-4-26B-A4B-it (large, MoE):**
+
+```
+| model                          |       size |     params | backend    | ngl |            test |                  t/s |
+| ------------------------------ | ---------: | ---------: | ---------- | --: | --------------: | -------------------: |
+| gemma4 26B.A4B Q4_K - Medium   |  15.70 GiB |    25.23 B | Vulkan     | 999 |           pp256 |        326.38 ± 1.58 |
+| gemma4 26B.A4B Q4_K - Medium   |  15.70 GiB |    25.23 B | Vulkan     | 999 |           tg128 |         19.67 ± 0.09 |
+
+build: 70b54e1 (9608)
+```
+
+**Qwen3-8B (small, dense):**
+
+```
+| model                          |       size |     params | backend    | ngl |            test |                  t/s |
+| ------------------------------ | ---------: | ---------: | ---------- | --: | --------------: | -------------------: |
+| qwen3 8B Q8_0                  |   8.11 GiB |     8.19 B | Vulkan     | 999 |           pp256 |        461.13 ± 5.21 |
+| qwen3 8B Q8_0                  |   8.11 GiB |     8.19 B | Vulkan     | 999 |           tg128 |          9.46 ± 0.01 |
+
+build: 70b54e1 (9608)
+```
+
+**gemma-4-26B-A4B-it (large, MoE) — TheRock ROCm 7.13.0:**
+
+```
+ggml_cuda_init: found 1 ROCm devices (Total VRAM: 27935 MiB):
+  Device 0: AMD Radeon 890M Graphics, gfx1150 (0x1150), VMM: no, Wave Size: 32, VRAM: 27935 MiB
+| model                          |       size |     params | backend    | ngl |            test |                  t/s |
+| ------------------------------ | ---------: | ---------: | ---------- | --: | --------------: | -------------------: |
+| gemma4 26B.A4B Q4_K - Medium   |  15.70 GiB |    25.23 B | ROCm       | 999 |           pp256 |        310.42 ± 6.31 |
+| gemma4 26B.A4B Q4_K - Medium   |  15.70 GiB |    25.23 B | ROCm       | 999 |           tg128 |         17.57 ± 0.34 |
+
+build: unknown (0)
+```
+
+(`build: unknown (0)` — see "TheRock ROCm build" above: the copied source
+tree has no `.git`, so `llama.cpp`'s build-info script can't populate the
+banner. Source `COMMIT` file confirms `70b54e1`, matching the Vulkan
+baseline exactly.)
+
+**Qwen3-8B (small, dense) — TheRock ROCm 7.13.0:**
+
+```
+ggml_cuda_init: found 1 ROCm devices (Total VRAM: 27935 MiB):
+  Device 0: AMD Radeon 890M Graphics, gfx1150 (0x1150), VMM: no, Wave Size: 32, VRAM: 27935 MiB
+| model                          |       size |     params | backend    | ngl |            test |                  t/s |
+| ------------------------------ | ---------: | ---------: | ---------- | --: | --------------: | -------------------: |
+| qwen3 8B Q8_0                  |   8.11 GiB |     8.19 B | ROCm       | 999 |           pp256 |        445.80 ± 7.12 |
+| qwen3 8B Q8_0                  |   8.11 GiB |     8.19 B | ROCm       | 999 |           tg128 |          8.51 ± 0.11 |
+
+build: unknown (0)
+```
+
+## Validity gate — GPU utilisation evidence
+
+Both runs were monitored with `amdgpu_top -J -n 1 -s 150` sampled continuously
+for the process lifetime (JSON `devices[0].gpu_activity.GFX` field = GRBM GFX
+busy %). Idle baseline before the model started computing was ~1-3%; both
+runs climbed to ~99-100% busy during the pp/tg phases, confirming the Vulkan
+backend actually executed on the GPU rather than falling back to CPU.
+
+**Qwen3-8B** (213 samples across the whole run):
+
+- max GFX busy: 100%
+- mean GFX busy: 94.8%
+- samples >50% busy: 205 / 213
+- first 20 samples (ramp-up from idle): `1, 2, 7, 12, 17, 17, 31, 43, 53, 63, 70, 75, 80, 84, 87, 89, 91, 92, 93, 95`
+- last 20 samples (steady state): `100, 99, 99, 99, 99, 99, 99, 99, 99, 99, 99, 99, 99, 99, 99, 99, 99, 99, 99, 86`
+
+**gemma-4-26B-A4B** (163 samples across the whole run):
+
+- max GFX busy: 99%
+- mean GFX busy: 69.5% (lower mean because model load + first pp warmup dominate more of the shorter overall wall time before ramping up)
+- samples >50% busy: 109 / 163
+- first 20 samples (idle during load): `2, 2, 3, 2, 2, 2, 2, 3, 3, 3, 3, 3, 3, 3, 3, 3, 4, 3, 3, 3`
+- last 20 samples (steady state): `99, 99, 99, 99, 99, 99, 98, 99, 99, 99, 99, 99, 99, 99, 99, 99, 99, 98, 96, 80`
+
+`llama-bench`'s own startup banner also confirms the Vulkan device was selected
+and layers offloaded (`ngl 999` in the results table, `ggml_vulkan: Found 1
+Vulkan devices` / `load_backend: loaded Vulkan backend` in stderr) — no CPU
+fallback occurred.
+
+The TheRock ROCm runs were monitored the same way (`amdgpu_top -J -n <N> -s
+150` for the process lifetime).
+
+**Qwen3-8B, TheRock ROCm** (183 samples across the whole run):
+
+- max GFX busy: 100%
+- mean GFX busy: 84.8%
+- samples >50% busy: 157 / 183
+- last 20 samples (steady state): `100, 100, 100, 100, 100, 100, 100, 100, 100, 100, 100, 100, 100, 100, 100, 100, 100, 100, 100, 100`
+
+**gemma-4-26B-A4B, TheRock ROCm** (250 samples; monitor window ran longer
+than the bench process, so the tail is post-exit idle, not part of the run):
+
+- max GFX busy: 100%
+- mean GFX busy: 63.6% (skewed down by ~150 idle samples after the process exited)
+- samples >50% busy: 157 / 250
+- first 20 samples (idle during load): all `0`
+- samples 100-120 (steady state, mid-run): `100, 100, 100, 100, 100, 100, 100, 100, 100, 100, 100, 100, 100, 100, 100, 100, 100, 100, 100, 100, 100`
+
+`llama-bench`'s startup banner also confirms the ROCm device was selected
+(`ggml_cuda_init: found 1 ROCm devices ... Device 0: AMD Radeon 890M
+Graphics, gfx1150 (0x1150)`, `backend | ROCm` and `ngl 999` in the results
+table) — no CPU fallback occurred on either run.
+
+## Status
+
+**Done.** Both baselines measured with the same methodology, same model
+files, same matched llama.cpp source commit (`70b54e1` / nixpkgs build
+9608). Vulkan (RADV) outperforms TheRock ROCm 7.13.0 on this gfx1150 host
+across both models and both metrics — see the summary at the top of this
+doc and the B3 build-effort section for why TheRock is still notably harder
+to stand up than Vulkan (which just works via nixpkgs' `llama-cpp-vulkan`
+with zero extra toolchain wrangling).
+
+## gfx1150 preliminary verdict (Phase 0, Task 4)
+
+**For llama.cpp on gfx1150, up-to-date TheRock ROCm does NOT beat Vulkan —
+it loses by ~3–5% prefill and ~10–11% decode, and costs far more to build
+and ship.** This extends the repo README's existing "Vulkan wins" finding
+from *old* nixpkgs ROCm 7.2.3 to *current* TheRock ROCm 7.13.0: newer ROCm
+did not close the gap. Cost side: the SDK is a ~350 KB/s / 16 GB fetch and
+the build needed four undocumented NixOS-specific fixes (~2 h). So the
+premise "latest ROCm ⇒ better llama.cpp" is **falsified on this hardware**.
+
+**This is NOT the decisive result.** It is gfx1150 (Strix Point), where both
+backends already work. The real target is **gfx1151 (Strix Halo)**, and two
+questions remain genuinely open there, both hardware-gated:
+
+1. **gfx1151 llama.cpp:** old nixpkgs ROCm 7.2.3 is *broken* on gfx1151 (VRAM
+   faults), and TheRock ships *native gfx1151 kernels*. The gfx1150 numbers
+   strongly suggest Vulkan still wins — but only the gfx1151 A/B settles it.
+2. **Image gen (sd-cpp):** not yet tested; the likeliest place ROCm still
+   beats Vulkan. Needs a Vulkan-sd-cpp-vs-TheRock-ROCm-sd A/B.
+
+**Lean:** for llama.cpp, Vulkan-first looks right even against latest ROCm;
+do not vendor TheRock on the "newer ROCm" premise alone. Hold the go/no-go
+until the gfx1151 runs (Task 5) — decisive for llama, and the first look at
+the sd-cpp question where ROCm has its best case.
+
+## Community gfx1151 data changes the regime this eval measured (IMPORTANT)
+
+The gfx1150 A/B above measured **short context (pp512/tg128) with a plain HIP
+build (no rocWMMA/hipBLASLt tuning)** — which is ROCm's *worst* case. The
+canonical Strix Halo benchmarks (llm-tracker.info/_TOORG/Strix-Halo,
+hogeheer499/strix-halo-guide, llama.cpp discussion #15021) show two things
+that flip the picture for the coding-agent (long-context) goal:
+
+- **Short ctx (pp512/tg128), gfx1151:** fully-optimized **HIP + rocWMMA + FA +
+  hipBLASLt** ≈ Vulkan (pp512 986 vs 884 — HIP *wins* prefill; tg128 50.6 vs
+  52.7 — Vulkan wins decode by a hair). Not the loss plain-HIP showed.
+- **Long ctx (8K), gfx1151:** the reversal — **HIP+rocWMMA+FA holds tg8192
+  ≈51 t/s while Vulkan+FA collapses to ≈32 t/s (~60% ROCm decode win)**;
+  Vulkan keeps a prefill lead. llm-tracker's explicit call: for
+  agentic/long-context, HIP+rocWMMA+FA is superior.
+
+**Implications:**
+1. "Vulkan-first for llama" holds only for **short context**. For long
+   context (8K–32K+, the coding-agent regime — the actual reason for Strix
+   Halo), **optimized ROCm+rocWMMA wins decode by a wide margin.**
+2. The winning ROCm config is specific: **rocWMMA + Flash-Attention +
+   hipBLASLt**. The flake's `llama-cpp-rocm` is plain (rocWMMA off — it
+   *regressed* on gfx1150). Realizing the gfx1151 win needs a **per-arch
+   build: rocWMMA ON for gfx1151, OFF for gfx1150.**
+3. On gfx1151 nixpkgs ROCm 7.2.3 *faults*, so the long-context win likely
+   needs **newer ROCm (TheRock) + rocWMMA + FA + hipBLASLt** together — a
+   narrow, specific case for up-to-date ROCm, not the vague "newer is better"
+   premise (which this gfx1150 run correctly falsified).
+
+**Task 5 correction:** the decisive gfx1151 eval MUST test **long context
+(8K/16K/32K)** with the **fully-optimized ROCm build (rocWMMA+FA+hipBLASLt)**,
+not pp512/tg128 plain-HIP — otherwise it measures ROCm's worst case and
+misses its only win. Image-gen (sd-cpp) is unaffected (not long-token-decode)
+— Vulkan sd-cpp remains the right cheap path there.


### PR DESCRIPTION
Recovers the Phase 0 TheRock evaluation from `feat/therock-rocm` — 8 commits that were never PR'd and had gone stale against main. Docs only; the branch's code delta was pure staleness (it predates vLLM, ds4, #70 and #81), so only the three new docs are carried over. Content is unchanged from the original commits.

Feeds #61:

- **gfx1150 result:** TheRock ROCm 7.13 loses to Vulkan on both models and both metrics — ~3-5% prefill, ~10-11% decode. Extends the README's existing "Vulkan wins" finding from nixpkgs ROCm 7.2.3 to current TheRock, so "newer ROCm means better llama.cpp" is falsified on this hardware.
- **Regime correction:** community gfx1151 data shows the gfx1150 A/B measured ROCm's *worst* case (short context, plain HIP). At 8K context on gfx1151, HIP+rocWMMA+FA holds ~51 t/s decode while Vulkan+FA collapses to ~32 t/s. So "Vulkan-first" holds for short context only.
- **Consequence for #61:** the decisive gfx1151 run must test long context with a fully-optimized ROCm build (rocWMMA + FA + hipBLASLt), not pp512/tg128 plain-HIP. Verified still accurate against main: rocWMMA is off in the flake and ROCm is still 7.2.3.

Does not close #61 — the gfx1151 measurement is the open half. Landing this so the collected numbers and the methodology correction stop rotting on an unsubmitted branch.