### PR TITLE
fix(scripts): move the unstable- version date when bumping xrt revs

### DIFF
--- a/pkgs/xrt-plugin-amdxdna/default.nix
+++ b/pkgs/xrt-plugin-amdxdna/default.nix
@@ -21,7 +21,7 @@ let
 in
   stdenv.mkDerivation rec {
     pname = "xrt-plugin-amdxdna";
-    version = "1.7-unstable-2025-06-06";
+    version = "1.7-unstable-2026-07-22";
     pluginVersion = "2.21.0";
 
     src = fetchFromGitHub {

--- a/pkgs/xrt/default.nix
+++ b/pkgs/xrt/default.nix
@@ -27,7 +27,7 @@
 stdenv.mkDerivation rec {
   pname = "xrt";
   # Pinned to the commit that amd/xdna-driver branch 1.7 references as a submodule
-  version = "unstable-2025-06-06";
+  version = "unstable-2026-06-04";
 
   src = fetchFromGitHub {
     owner = "Xilinx";

--- a/scripts/bump-versions.sh
+++ b/scripts/bump-versions.sh
@@ -9,6 +9,19 @@ LEM_NEW="$3" LEM_OLD="$4"
 XDNA_NEW="$5" XDNA_OLD="$6"
 VLLM_NEW="${7:-}" VLLM_OLD="${8:-}"
 
+# The unstable-YYYY-MM-DD date names the pinned rev, so it has to move with it.
+update_unstable_date() {
+  local repo="$1" rev="$2" file="$3"
+  local date
+  date=$(gh api "repos/$repo/commits/$rev" --jq '.commit.committer.date[0:10]' || true)
+  if [ -n "$date" ]; then
+    sed -i "s/\(version = \"[^\"]*unstable-\)[0-9-]\{10\}\"/\1$date\"/" "$file"
+    echo "  Version date updated: $date"
+  else
+    echo "  WARNING: could not resolve commit date for $repo@${rev:0:12}"
+  fi
+}
+
 update_hash() {
   local pkg="$1"
   echo "  Prefetching hash for $pkg..."
@@ -59,6 +72,7 @@ if [ "$XDNA_NEW" != "$XDNA_OLD" ]; then
   echo "Bumping xdna-driver: ${XDNA_OLD:0:12} -> ${XDNA_NEW:0:12}"
   sed -i "s/rev = \"$XDNA_OLD\"/rev = \"$XDNA_NEW\"/" pkgs/xrt-plugin-amdxdna/default.nix
   sed -i 's/hash = "sha256-[^"]*"/hash = ""/' pkgs/xrt-plugin-amdxdna/default.nix
+  update_unstable_date amd/xdna-driver "$XDNA_NEW" pkgs/xrt-plugin-amdxdna/default.nix
 
   # Check if XRT submodule also changed
   NEW_XRT_REV=$(gh api "repos/amd/xdna-driver/contents/xrt?ref=$XDNA_NEW" --jq '.sha' || true)
@@ -68,6 +82,7 @@ if [ "$XDNA_NEW" != "$XDNA_OLD" ]; then
       echo "  XRT submodule also changed: ${OLD_XRT_REV:0:12} -> ${NEW_XRT_REV:0:12}"
       sed -i "s/rev = \"$OLD_XRT_REV\"/rev = \"$NEW_XRT_REV\"/" pkgs/xrt/default.nix
       sed -i 's/hash = "sha256-[^"]*"/hash = ""/' pkgs/xrt/default.nix
+      update_unstable_date Xilinx/XRT "$NEW_XRT_REV" pkgs/xrt/default.nix
       update_hash xrt
     fi
   fi


### PR DESCRIPTION
The xdna-driver branch of `bump-versions.sh` rewrites `rev` and `hash` for both `xrt` and `xrt-plugin-amdxdna`, but never the `version` string — unlike the FastFlowLM, lemonade and vLLM branches, which all do. So both packages sat at `unstable-2025-06-06` while their pinned revs moved on:

| Package | Declared | Pinned rev's actual commit date |
|---|---|---|
| `xrt` | `unstable-2025-06-06` | **2026-06-04** (`8661761`) |
| `xrt-plugin-amdxdna` | `1.7-unstable-2025-06-06` | **2026-07-22** (`4e5aed38`) |

Both were wrong by more than a year — noticed while tracing #79, where the plugin version was misleading about which shim was actually in the closure.

Adds `update_unstable_date`, which resolves the rev's commit date via `gh` and rewrites only the date component, preserving any prefix (`1.7-`). Wired into both the plugin bump and the XRT-submodule bump, and corrects the two current strings.

Verified:
- `shellcheck` clean
- the sed rewrites both `unstable-` forms and leaves plain semver (`0.9.46`) untouched
- `nix eval` gives `xrt-unstable-2026-06-04` and `xrt-plugin-amdxdna-1.7-unstable-2026-07-22`

Neither package derives its `rev` from `version`, so no src hash is affected — only the derivation name.