### PR TITLE
README: add Strix Halo (gfx1151) NPU measurements + small-model caveat

### DIFF
--- a/README.md
+++ b/README.md
@@ -412,6 +412,24 @@ All numbers measured on Strix Point (gfx1150, Radeon 890M iGPU, 64 GiB DDR5-5600
 
 Notes: FLM's TTFT is dominated by a one-off NPU compile-to-cache; steady-state decode is the useful number. FLM's GGUF-vs-proprietary format means quantization isn't bit-identical to the llamacpp row, so treat these as same-family, not same-weights.
 
+### Strix Halo (gfx1151 / XDNA2 NPU5): NPU measured
+
+The tables above are Strix Point. These rows are from a Strix Halo host: ASUS ROG Flow Z13 (GZ302EA), Ryzen AI MAX+ 395, 128 GB, NixOS 26.11, kernel 7.1.0 with in-tree `amdxdna` 0.8, NPU firmware 1.1.2.65, `fastflowlm` 0.9.43. The NPU reports **8 columns** here, versus fewer on Strix Point, which is the likely source of the throughput difference against community Strix Point figures for the same model.
+
+| Test | Result |
+| ---- | ------ |
+| `flm validate` | rc=0, 8-column NPU, FW 1.1.2.65, `Memlock Limit: infinity` |
+| Llama-3.2-1B (q4nx, `--pmode performance`) | **~49–50 t/s** decode |
+| Llama-3.1-8B | ~8 t/s decode |
+| Package power (RAPL), idle → 1B inference | 5.1 W → 19.5 W (**+14.4 W**, includes CPU serving overhead) |
+| **NPU 1B + iGPU ROCm 7B concurrently** | NPU ~40 t/s, **iGPU 37.1 t/s (full speed, no degradation)**, 36.2 W total |
+
+The concurrency row is the interesting one: an NPU workload running alongside an iGPU ROCm workload costs the iGPU nothing measurable and costs the NPU about 20%. That is a genuine low-power co-processor for small models while the iGPU handles 7B and up — not a way to make one model faster.
+
+**The NPU niche on Halo is genuinely small models (1–3B).** At 8B the NPU manages ~8 t/s while the iGPU runs the same class of model several times faster, so the NPU is a power and concurrency play, never a throughput win. Route big models to Vulkan/ROCm and keep the NPU for the small resident one.
+
+**Firmware on kernel ≥7.0 needs no DKMS.** In-tree `amdxdna` prefers `amdnpu/17f0_11/npu_7.sbin` (→ `1.1.2.65`) over the default `npu.sbin` (→ `1.0.0.166`), so FastFlowLM's ≥1.1.0.0 requirement is met out of the box. Check with `cat /sys/class/accel/accel0/device/fw_version`.
+
 **Recommendation:**
 
 - **General LLM inference (7B–26B Q4):** use **Vulkan**. On Strix Point 890M with llama.cpp b8770, Vulkan wins decode at every size tested and ties or wins prefill. The previous "ROCm for prefill-heavy" advice no longer holds now that ROCm targets gfx1150 natively (the gfx1102 Tensile arch-logic was apparently more tuned than gfx1150's is today).

--- a/README.md
+++ b/README.md
@@ -414,7 +414,7 @@ Notes: FLM's TTFT is dominated by a one-off NPU compile-to-cache; steady-state d
 
 ### Strix Halo (gfx1151 / XDNA2 NPU5): NPU measured
 
-The tables above are Strix Point. These rows are from a Strix Halo host: ASUS ROG Flow Z13 (GZ302EA), Ryzen AI MAX+ 395, 128 GB, NixOS 26.11, kernel 7.1.0 with in-tree `amdxdna` 0.8, NPU firmware 1.1.2.65, `fastflowlm` 0.9.43. The NPU reports **8 columns** here, versus fewer on Strix Point, which is the likely source of the throughput difference against community Strix Point figures for the same model.
+The tables above are Strix Point. These rows are from a Strix Halo host: ASUS ROG Flow Z13 (GZ302EA), Ryzen AI MAX+ 395, 128 GB, NixOS 26.11, kernel 7.1.0 with in-tree `amdxdna` 0.8, NPU firmware 1.1.2.65, `fastflowlm` 0.9.43. These figures run ahead of community Strix Point numbers for the same model, but the cause is not established here and nothing below depends on it. (It is not the column count: Strix Point, Krackan and Halo are all XDNA2 with the same 8-column array, as noted above for Krackan.)
 
 | Test | Result |
 | ---- | ------ |


### PR DESCRIPTION
The README's NPU numbers are all Strix Point (gfx1150). I have a Strix Halo host, so here are measured numbers from it, in their own subsection so nothing about the existing Strix Point table changes.

This is the PR you asked for in #42.

**Host:** ASUS ROG Flow Z13 (GZ302EA) — Ryzen AI MAX+ 395, XDNA2 NPU5 (PCI `1022:17f0` rev `0x11`, `RyzenAI-npu5`, **8 columns**), 128 GB. NixOS 26.11, kernel 7.1.0 (mainline `linuxPackages_latest`, in-tree `amdxdna` 0.8), NPU firmware 1.1.2.65, this flake's `fastflowlm` 0.9.43.

Three things worth having in the README:

1. **The concurrency result.** Running an NPU model alongside an iGPU ROCm workload costs the iGPU nothing measurable and the NPU about 20%. That's the concrete evidence for the "NPU as a low-power co-processor while the iGPU does the big model" framing, and I couldn't find it documented anywhere.
2. **The small-model caveat.** 8B on the NPU is ~8 t/s. Halo users shouldn't expect 7B-class throughput from the NPU.
3. **In-tree `amdxdna` on kernel ≥7.0 satisfies FastFlowLM's firmware floor with no DKMS**, at least on Halo.

Per your #42 comment I've left the `gpuMemory` ttm caveat alone — that tuning wasn't exercised by this run. Measured values for it are a separate follow-up, which I'll put on #42.

### On the memlock note from #42

You were right and I was wrong: the 8 MB `MAP_LOCKED` wall I hit was an artifact of hand-rolling `xrt-combined` from the standalone derivations instead of using the module. With `enableNPU = true` the module's `security.pam.loginLimits` entry for `@video`/`@render` handles it — confirmed on this host, where `flm validate` now prints `Memlock Limit: infinity` for an ordinary unprivileged user. I haven't put a "replicate the module's memlock limit if you bypass the module" line in this diff; say the word and I'll add one wherever you think it belongs.

### Housekeeping, not part of this diff

Those benchmark tables currently render *inside* `## ds4 (DeepSeek V4 on Strix Halo)`, because the "All numbers measured on Strix Point…" preamble has no heading of its own — so a section of Gemma/Qwen Strix Point benchmarks reads as though it belongs to the Halo-only ds4 engine. I've inserted my subsection after those tables and before the **Recommendation:** block, which keeps things contiguous, but happy to add a `## Benchmarks` heading here or leave it to you.

The NPU rows were measured 2026-06-24; `flm validate` re-confirmed 2026-08-27.