### PR TITLE
fix(scripts): select vllm-rocm releases by target coverage, key hashes by URL

### DIFF
--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -150,8 +150,6 @@ jobs:
             BODY+=$'\n'"### ⚠️ Build failures"$'\n'"$BUILD_FAILED"
           fi
 
-          BODY+=$'\n'"**Note:** Hashes may need manual correction if auto-prefetch failed."
-
           PR_URL=$(echo "$BODY" | gh pr create --title "chore: bump upstream package versions" --body-file -)
           echo "pr_url=$PR_URL" >> "$GITHUB_OUTPUT"
 

--- a/scripts/bump-versions.sh
+++ b/scripts/bump-versions.sh
@@ -22,17 +22,44 @@ update_unstable_date() {
   fi
 }
 
+# The workflow opens — and on the clean path auto-merges — whatever tree this
+# leaves behind, so a hash we could not prefetch has to fail the job.
 update_hash() {
   local pkg="$1"
   echo "  Prefetching hash for $pkg..."
   local new_hash
   new_hash=$(nix build ".#$pkg" 2>&1 | grep -oP 'got:\s+\K\S+' || true)
-  if [ -n "$new_hash" ]; then
-    sed -i "s|hash = \"\"|hash = \"$new_hash\"|" "pkgs/$pkg/default.nix"
-    echo "  Hash updated: $new_hash"
-  else
-    echo "  WARNING: could not auto-prefetch hash for $pkg"
+  if [ -z "$new_hash" ]; then
+    echo "ERROR: could not auto-prefetch hash for $pkg" >&2
+    exit 1
   fi
+  sed -i "s|hash = \"\"|hash = \"$new_hash\"|" "pkgs/$pkg/default.nix"
+  echo "  Hash updated: $new_hash"
+}
+
+# Release tags come in two shapes — `vllm<ver>+rocm<...>` nightlies and
+# `vllm-omni<ver>-rocm<...>` cuts. Both reduce to the bare version.
+vllm_version() {
+  local v="${1#vllm}"
+  v="${v#-}"
+  v="${v%%+*}"
+  printf '%s' "${v%-rocm*}"
+}
+
+# Keyed by URL rather than file position: a positional fill shifts every later
+# hash into the wrong part as soon as one prefetch fails.
+set_part_hash() {
+  local file="$1" url="$2" hash="$3"
+  grep -qF "$url" "$file" || {
+    echo "ERROR: no part in $file has url $url" >&2
+    exit 1
+  }
+  awk -v url="$url" -v h="$hash" '
+    index($0, url) {found = 1}
+    found && /hash = / {sub(/hash = "[^"]*"/, "hash = \"" h "\""); found = 0}
+    {print}
+  ' "$file" >"$file.tmp"
+  mv "$file.tmp" "$file"
 }
 
 # FastFlowLM
@@ -58,13 +85,12 @@ if [ "$LEM_NEW" != "$LEM_OLD" ]; then
   # (works on the Linux CI runner, where the aarch64-darwin package can't build).
   echo "  Prefetching macOS embeddable hash..."
   darwin_url="https://github.com/lemonade-sdk/lemonade/releases/download/v${LEM_NEW}/lemonade-embeddable-${LEM_NEW}-macos-arm64.tar.gz"
-  darwin_hash=$(nix store prefetch-file --json "$darwin_url" | jq -r .hash || true)
-  if [ -n "$darwin_hash" ]; then
-    sed -i "s|hash = \"sha256-[^\"]*\"|hash = \"$darwin_hash\"|" pkgs/lemonade/darwin.nix
-    echo "  macOS hash updated: $darwin_hash"
-  else
-    echo "  WARNING: could not prefetch macOS embeddable hash for $LEM_NEW"
+  if ! darwin_hash=$(nix store prefetch-file --json "$darwin_url" | jq -er .hash); then
+    echo "ERROR: could not prefetch macOS embeddable hash for $LEM_NEW" >&2
+    exit 1
   fi
+  sed -i "s|hash = \"sha256-[^\"]*\"|hash = \"$darwin_hash\"|" pkgs/lemonade/darwin.nix
+  echo "  macOS hash updated: $darwin_hash"
 fi
 
 # xdna-driver (also check XRT submodule)
@@ -92,33 +118,35 @@ fi
 
 # vLLM-ROCm — prebuilt per-gfx split bundles. The base tag (minus -gfxNNNN)
 # appears plain in each releaseTag and URL-encoded (+ -> %2B) in each URL, so
-# swap both, then blank and refill the four hashes in file order (gfx1150 p1/p2,
-# gfx1151 p1/p2) via direct prefetch — nix build can't emit per-part hashes.
+# swap both, then refetch every part's hash by URL — nix build can't emit
+# per-part hashes.
 if [ -n "$VLLM_NEW" ] && [ "$VLLM_NEW" != "$VLLM_OLD" ]; then
   echo "Bumping vLLM-ROCm: $VLLM_OLD -> $VLLM_NEW"
   src=pkgs/vllm-rocm/sources.nix
   old_enc="${VLLM_OLD//+/%2B}"
   new_enc="${VLLM_NEW//+/%2B}"
-  old_ver="${VLLM_OLD#vllm}"; old_ver="${old_ver%%+*}"
-  new_ver="${VLLM_NEW#vllm}"; new_ver="${new_ver%%+*}"
+  old_ver=$(vllm_version "$VLLM_OLD")
+  new_ver=$(vllm_version "$VLLM_NEW")
 
   sed -i "s|$old_enc|$new_enc|g; s|$VLLM_OLD|$VLLM_NEW|g" "$src"
-  [ "$old_ver" != "$new_ver" ] && sed -i "s/version = \"$old_ver\"/version = \"$new_ver\"/g" "$src"
-  sed -i 's/hash = "sha256-[^"]*"/hash = ""/' "$src"
+  if [ "$old_ver" != "$new_ver" ]; then
+    sed -i "s/version = \"$old_ver\"/version = \"$new_ver\"/g" "$src"
+  fi
 
   base_url="https://github.com/lemonade-sdk/vllm-rocm/releases/download"
-  for target in gfx1150 gfx1151; do
+  mapfile -t targets < <(sed -n 's/^  \(gfx[0-9a-zA-Z]*\) = {$/\1/p' "$src")
+  for target in "${targets[@]}"; do
     enctag="${new_enc}-${target}"
     for part in part01-of-02 part02-of-02; do
       url="${base_url}/${enctag}/${enctag}-x64.${part}.tar.gz"
       echo "  Prefetching $target $part..."
-      h=$(nix store prefetch-file --json "$url" | jq -r .hash || true)
-      if [ -n "$h" ]; then
-        sed -i "0,/hash = \"\"/s||hash = \"$h\"|" "$src"
-        echo "    $h"
-      else
-        echo "  WARNING: could not prefetch $target $part"
+      if ! h=$(nix store prefetch-file --json "$url" | jq -er .hash); then
+        echo "ERROR: could not prefetch $target $part" >&2
+        echo "       $url" >&2
+        exit 1
       fi
+      set_part_hash "$src" "$url" "$h"
+      echo "    $h"
     done
   done
 fi

--- a/scripts/check-updates.sh
+++ b/scripts/check-updates.sh
@@ -6,9 +6,27 @@ set -euo pipefail
 FLM_LATEST=$(gh api repos/FastFlowLM/FastFlowLM/releases/latest --jq '.tag_name' | sed 's/^v//')
 LEM_LATEST=$(gh api repos/lemonade-sdk/lemonade/releases/latest --jq '.tag_name' | sed 's/^v//')
 XDNA_LATEST=$(gh api "repos/amd/xdna-driver/commits?sha=1.7&per_page=1" --jq '.[0].sha')
-# vLLM-ROCm cuts one dated nightly per gfx target; strip the -gfxNNNN suffix to
-# get the shared base tag every target pins to.
-VLLM_LATEST=$(gh api repos/lemonade-sdk/vllm-rocm/releases/latest --jq '.tag_name' | sed 's/-gfx[^-]*$//')
+# vLLM-ROCm cuts one release per gfx target, so `releases/latest` returns
+# whichever target shipped last — routinely one we don't consume (gfx950,
+# gfx942). Its base tag may have no build for our targets at all, which then
+# 404s at prefetch time and downgrades the pin. Walk releases newest-first and
+# take the first base tag built for every target sources.nix consumes.
+mapfile -t VLLM_TARGETS < <(sed -n 's/^  \(gfx[0-9a-zA-Z]*\) = {$/\1/p' pkgs/vllm-rocm/sources.nix)
+VLLM_TAGS=$(gh api "repos/lemonade-sdk/vllm-rocm/releases?per_page=100" \
+  --jq '.[] | select(.draft | not) | .tag_name')
+VLLM_LATEST=""
+while read -r base; do
+  for target in "${VLLM_TARGETS[@]}"; do
+    grep -qxF "${base}-${target}" <<<"$VLLM_TAGS" || continue 2
+  done
+  VLLM_LATEST="$base"
+  break
+done < <(sed -n 's/-gfx[^-]*$//p' <<<"$VLLM_TAGS" | awk '!seen[$0]++')
+
+if [ -z "$VLLM_LATEST" ]; then
+  echo "ERROR: no vllm-rocm release covers all targets: ${VLLM_TARGETS[*]}" >&2
+  exit 1
+fi
 
 FLM_CURRENT=$(grep 'version = ' pkgs/fastflowlm/default.nix | head -1 | sed 's/.*"\(.*\)".*/\1/')
 LEM_CURRENT=$(sed -n 's/.*"\(.*\)".*/\1/p' pkgs/lemonade/version.nix | head -1)


### PR DESCRIPTION
The weekly update workflow has been producing broken vLLM-ROCm bumps — #92 is the visible symptom. Four separate defects, all in the vLLM path.

### 1. `releases/latest` picks a target we don't consume

`check-updates.sh` derived the base tag from `repos/lemonade-sdk/vllm-rocm/releases/latest`. But vllm-rocm cuts **one release per gfx target**, so `releases/latest` returns whichever target happened to ship last. Right now that is:

```
vllm0.19.1-rocm7.13.0-gfx950   ->  base tag  vllm0.19.1-rocm7.13.0
```

That base tag has no `gfx1150` or `gfx1151` build at all, and `0.19.1` is a **downgrade** from the pinned `0.23.1` — which the script's plain string-inequality check can't detect. The next scheduled run would have opened another broken PR.

Now: walk releases newest-first and take the first base tag that has a build for every target `sources.nix` consumes. Verified against the live API:

| | base tag selected |
|---|---|
| before | `vllm0.19.1-rocm7.13.0` (gfx950 only, downgrade) |
| after | `vllm0.25.2.dev0+rocm7.15.0a20260724.g752a3a504.d20260724-rocm7.15.0` (has both) |

Note this also means `vllm-omni*` cuts won't be selected while they ship gfx1151 only — the correct outcome given `sources.nix` pins both targets.

### 2. Hashes were filled positionally, so one failure corrupted the rest

`bump-versions.sh` blanked all four hashes and refilled with

```sh
sed -i "0,/hash = \"\"/s||hash = \"$h\"|" "$src"
```

which fills the *first remaining* blank regardless of which part was just prefetched. In #92, `vllm-omni0.25.0rc1-rocm7.15.0` exists **only for gfx1151**, so:

- gfx1150 p1, p2 → 404 → warning, nothing written
- gfx1151 p1, p2 → succeeded → **landed in gfx1150's two slots**

Result: gfx1150 carried gfx1151's hashes against a URL that 404s, and gfx1151 was left `hash = ""`. Hashes are now set by matching each part's unique URL (`set_part_hash`), and a URL not found in the file is a hard error.

### 3. Failed prefetches were warnings

The workflow opens — and on the clean path **auto-merges** — whatever tree the bump leaves behind, so a half-filled bump has to fail the job, not land as a PR. All prefetch failures now exit non-zero. The "Hashes may need manual correction if auto-prefetch failed" line in the PR template goes away with it.

### 4. Version derivation broke on the `vllm-omni` tag scheme

`${VLLM_NEW#vllm}` assumed `vllm<ver>+rocm<...>`. On `vllm-omni0.25.0rc1-rocm7.15.0` it produced `version = "-omni0.25.0rc1-rocm7.15.0"` (leading dash, keeps the rocm suffix) — visible in #92's diff. `vllm_version()` handles both shapes:

| tag | version |
|---|---|
| `vllm0.23.1.dev0+rocm7.15.0a…` | `0.23.1.dev0` |
| `vllm-omni0.25.0rc1-rocm7.15.0` | `omni0.25.0rc1` |

The target list is also read from `sources.nix` instead of being hardcoded in both scripts.

### Verification

- `shellcheck` clean on both scripts.
- `vllm_version` checked against all three tag shapes in the wild (table above).
- Release selection run against the live API (table above).
- `set_part_hash` on a copy of `sources.nix`: setting **only** gfx1151 part02 — the case where earlier prefetches failed — writes line 35 and leaves the other three untouched. The old code wrote line 12.
- The URL guard returns exit 1 on a URL not present in the file.

Not exercised: a full workflow run. The bump this unblocks follows in a separate PR.
