### PR TITLE
feat(module): declarative lemonade model list

### DIFF
--- a/README.md
+++ b/README.md
@@ -250,6 +250,44 @@ schemes are always allowed, so this only matters once `lemonade.host` is
 bound to something a LAN or remote browser can reach; the module warns if
 you set the former without the latter.
 
+### Declarative models: `lemonade.models`
+
+Models to keep downloaded, named as `lemonade list` reports them:
+
+```nix
+hardware.amd-npu.lemonade.models = [
+  "Qwen3.5-4B-MTP-GGUF"
+  "llama3.2-1b-FLM"
+];
+```
+
+A `lemond-models` unit pulls whatever is missing. Models already on disk are
+skipped, so re-activating an unchanged list costs nothing.
+
+**Activation does not block.** The unit is `Type=simple`, so systemd calls it
+started the moment it forks and `nixos-rebuild switch` returns immediately
+rather than sitting on multi-GiB downloads. Follow the pull with:
+
+```bash
+journalctl -fu lemond-models
+```
+
+It has to be a unit rather than an activation script because `lemonade pull` is
+an HTTP client — it needs `lemond` already answering, which is also why the
+unit waits for `lemonade status` before doing anything. A model that fails to
+pull is logged and skipped, so one bad name can't block the rest of the list.
+
+To make the set on disk *exactly* the declared one, add:
+
+```nix
+hardware.amd-npu.lemonade.pruneUnlistedModels = true;
+```
+
+This deletes downloaded models the list doesn't mention. It's off by default —
+models are large and slow to re-fetch, and anything pulled by hand for an
+experiment would vanish on the next activation. It requires a non-empty
+`lemonade.models`, so an empty list can never be read as "delete everything".
+
 ### Tauri desktop app: download progress is fragile when backgrounded
 
 WebKitGTK suspends the network process for windows that are minimized, hidden, or moved to another workspace. That kills the SSE progress stream lemond uses for downloads at ~60–90 s. Without our patch, that nuked the whole download mid-flight. With the patch, the download keeps running server-side and finishes regardless — but the UI stops seeing progress until you refocus the window (and may need a refresh to pick up the result). For very large pulls, prefer the regular browser at `http://localhost:13305` or `lemonade pull <model>` from the CLI; both survive backgrounding cleanly.

--- a/flake.nix
+++ b/flake.nix
@@ -464,6 +464,65 @@
                 touch $out
               '';
 
+            module-eval-lemonade-models = let
+              mkSys = lemonadeExtra:
+                (inputs.nixpkgs.lib.nixosSystem {
+                  inherit system;
+                  modules = [
+                    inputs.self.nixosModules.default
+                    {
+                      boot.loader.grub.enable = false;
+                      fileSystems."/" = {
+                        device = "/dev/sda1";
+                        fsType = "ext4";
+                      };
+                      hardware.amd-npu = {
+                        enable = true;
+                        enableLemonade = true;
+                        lemonade = {user = "testuser";} // lemonadeExtra;
+                      };
+                      users.users.testuser = {
+                        isNormalUser = true;
+                        extraGroups = ["video" "render"];
+                      };
+                    }
+                  ];
+                }).config;
+              declared = mkSys {models = ["Qwen3.5-4B-MTP-GGUF" "llama3.2-1b-FLM"];};
+              pruning = mkSys {
+                models = ["Qwen3.5-4B-MTP-GGUF"];
+                pruneUnlistedModels = true;
+              };
+              none = mkSys {};
+            in
+              pkgs.runCommand "module-eval-lemonade-models" {
+                unit = declared.systemd.units."lemond-models.service".unit;
+                pruneUnit = pruning.systemd.units."lemond-models.service".unit;
+                noneUnits = builtins.toJSON (builtins.attrNames none.systemd.units);
+              } ''
+                sync=$(sed -n 's/^ExecStart=//p' "$unit"/lemond-models.service)
+
+                # The pull must not block activation on multi-GiB downloads.
+                grep -qF 'Type=simple' "$unit"/lemond-models.service
+                grep -qF 'After=lemond.service' "$unit"/lemond-models.service
+
+                grep -qF 'Qwen3.5-4B-MTP-GGUF' "$sync"
+                grep -qF 'llama3.2-1b-FLM' "$sync"
+
+                # Deleting models is opt-in, so the prune branch must be absent
+                # unless pruneUnlistedModels asked for it.
+                ! grep -qF 'lemonade delete' "$sync"
+                grep -qF 'lemonade delete' "$(sed -n 's/^ExecStart=//p' "$pruneUnit"/lemond-models.service)"
+
+                # An empty models list generates no unit at all.
+                if grep -qF 'lemond-models.service' <<<"$noneUnits"; then
+                  echo "lemond-models.service generated with an empty lemonade.models" >&2
+                  exit 1
+                fi
+
+                touch $out
+              '';
+
             module-eval-lemonade-allowed-origins = let
               sys =
                 (inputs.nixpkgs.lib.nixosSystem {

--- a/modules/amd-npu.nix
+++ b/modules/amd-npu.nix
@@ -139,6 +139,57 @@
       fi
     '';
   };
+
+  # `lemonade pull` is an HTTP client for lemond, so models can only be
+  # reconciled against a running server — an activation script can't do it.
+  lemonadeModelSync = pkgs.writeShellApplication {
+    name = "lemond-sync-models";
+    runtimeInputs = [lemonadePackage pkgs.gawk pkgs.coreutils];
+    text = ''
+      declared=(${lib.escapeShellArgs cfg.lemonade.models})
+
+      # Unit ordering only guarantees lemond's process started, not that its
+      # port answers.
+      for _ in $(seq 60); do
+        if lemonade status >/dev/null 2>&1; then break; fi
+        sleep 2
+      done
+      if ! lemonade status >/dev/null 2>&1; then
+        echo "lemond unreachable after 120s; leaving models alone" >&2
+        exit 1
+      fi
+
+      # Column 1 of the `list` table, minus its header and rule lines.
+      downloaded() {
+        lemonade list --downloaded \
+          | awk 'NR > 2 && NF && $1 !~ /^-+$/ {print $1}'
+      }
+
+      have=$(downloaded)
+      for model in "''${declared[@]}"; do
+        if grep -qxF "$model" <<<"$have"; then
+          continue
+        fi
+        echo "pulling $model"
+        lemonade pull "$model" || echo "failed to pull $model" >&2
+      done
+    ''
+    + optionalString cfg.lemonade.pruneUnlistedModels ''
+
+      for model in $(downloaded); do
+        keep=false
+        for want in "''${declared[@]}"; do
+          if [ "$model" = "$want" ]; then
+            keep=true
+            break
+          fi
+        done
+        if [ "$keep" = true ]; then continue; fi
+        echo "deleting unlisted $model"
+        lemonade delete "$model" || echo "failed to delete $model" >&2
+      done
+    '';
+  };
 in {
   options.hardware.amd-npu = {
     enable = mkEnableOption "AMD NPU (AI Engine) support";
@@ -305,6 +356,37 @@ in {
           site the browser visits.
         '';
       };
+
+      models = mkOption {
+        type = types.listOf types.str;
+        default = [];
+        example = ["Qwen3.5-4B-MTP-GGUF" "llama3.2-1b-FLM"];
+        description = ''
+          Models to keep downloaded, named as `lemonade list` reports them.
+          Missing ones are pulled by a `lemond-models` unit; models already on
+          disk are left alone, so re-activating costs nothing.
+
+          The pull runs in the background — the unit is `Type=simple`, so
+          systemd calls it started the moment it forks and `nixos-rebuild
+          switch` returns without waiting on multi-GiB downloads. Follow it
+          with `journalctl -fu lemond-models`. A model that fails to pull is
+          logged and skipped rather than failing the unit, so one bad name
+          can't block the rest.
+        '';
+      };
+
+      pruneUnlistedModels = mkOption {
+        type = types.bool;
+        default = false;
+        description = ''
+          Also delete downloaded models that `lemonade.models` does not list,
+          making the set on disk exactly the declared one.
+
+          Off by default: models are large and slow to re-fetch, and anything
+          pulled by hand for an experiment would disappear on the next
+          activation. Requires a non-empty `lemonade.models`.
+        '';
+      };
     };
 
     ds4 = {
@@ -419,6 +501,14 @@ in {
       {
         assertion = !cfg.ds4.enable || cfg.ds4.model != null;
         message = "hardware.amd-npu.ds4.enable requires hardware.amd-npu.ds4.model (path to a DeepSeek V4 GGUF).";
+      }
+      {
+        assertion = cfg.lemonade.models == [] || cfg.enableLemonade;
+        message = "hardware.amd-npu.lemonade.models requires enableLemonade = true (models are pulled through a running lemond).";
+      }
+      {
+        assertion = !cfg.lemonade.pruneUnlistedModels || cfg.lemonade.models != [];
+        message = "hardware.amd-npu.lemonade.pruneUnlistedModels requires a non-empty lemonade.models; against an empty list it would delete every downloaded model.";
       }
       {
         assertion =
@@ -582,6 +672,22 @@ in {
         LimitMEMLOCK = "infinity";
         # WhisperServer resolves its writable runtime dir from RUNTIME_DIRECTORY.
         RuntimeDirectory = "lemond";
+      };
+    };
+
+    # systemd calls a Type=simple unit started as soon as it forks, so
+    # `nixos-rebuild switch` returns instead of waiting out multi-GiB pulls.
+    # A oneshot would make activation block on them.
+    systemd.services.lemond-models = mkIf (cfg.enableLemonade && cfg.lemonade.models != []) {
+      description = "Reconcile downloaded lemonade models";
+      after = ["lemond.service"];
+      requires = ["lemond.service"];
+      wantedBy = ["multi-user.target"];
+      serviceConfig = {
+        Type = "simple";
+        User = cfg.lemonade.user;
+        ExecStart = "${lemonadeModelSync}/bin/lemond-sync-models";
+        Restart = "no";
       };
     };
 


### PR DESCRIPTION
Closes #89 — @rabejens asked for a `lemonade.models` option that auto-downloads models on activation, in the background so `nixos-rebuild switch` doesn't sit for half an hour, plus a choice about whether unlisted models get deleted.

```nix
hardware.amd-npu.lemonade.models = [
  "Qwen3.5-4B-MTP-GGUF"
  "llama3.2-1b-FLM"
];
```

### Why a unit and not an activation script

`lemonade pull` is an **HTTP client for lemond** — it can't do anything until the server is answering. So this is a `lemond-models` unit ordered `After=lemond.service`, and the script waits on `lemonade status` before touching anything (unit ordering only guarantees lemond's *process* started, not that its port answers). If lemond never comes up within 120 s the unit gives up without touching models.

### Not blocking activation

The unit is **`Type=simple`, not `oneshot`.** systemd considers a simple unit started the moment it forks, so `nixos-rebuild switch` returns immediately and the pull continues in the background — which is the specific thing #89 asked for. A `oneshot` would look more natural for a run-once task and would reintroduce exactly the 30-minute switch the issue is about.

Progress: `journalctl -fu lemond-models`.

Already-downloaded models are skipped, so re-activating an unchanged list costs nothing. A model that fails to pull is logged and skipped rather than failing the unit, so one typo can't block the rest of the list.

### Pruning is opt-in and can't be pointed at everything

```nix
hardware.amd-npu.lemonade.pruneUnlistedModels = true;
```

Off by default: models are large and slow to re-fetch, and anything pulled by hand for an experiment would vanish on the next activation. An assertion requires a non-empty `lemonade.models`, so an empty list can never be read as "delete every downloaded model". The prune branch is not even *generated* into the script unless the option is on.

### Verification

- **`nix flake check --no-build`** — green, including the new `module-eval-lemonade-models` check.
- **New check asserts** the unit is `Type=simple` and `After=lemond.service`; both declared models reach the script; `lemonade delete` is **absent** without `pruneUnlistedModels` and present with it; and an empty `models` list generates no unit at all.
- **Negative control on the check** — swapping a declared model name for one that isn't declared makes it fail (exit 1), so it isn't green-by-construction.
- **`writeShellApplication` runs shellcheck** on the generated script; both the prune and no-prune variants build.
- **Ran the generated script against a live lemond** on my Strix Point box with both declared models already downloaded: exit 0, no pulls attempted — the intended idempotent no-op.

Two `set -e` traps caught during review and fixed: `writeShellApplication` sets `set -euo pipefail`, so `lemonade status ... && break` and `[ "$model" = "$want" ] && continue 2` would each have aborted the unit on their *false* branch. Both are `if` statements now.

**Not exercised:** the prune path against real data — running it would have deleted models off my working box. Its shape is covered by the eval check and shellcheck, but the first real prune deserves a careful eye.
