### PR TITLE
chore: bump lemonade 11.8.1, fastflowlm 1.0.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,7 +154,7 @@ hardware.amd-npu = {
 
 ### Why the module flags matter on NixOS
 
-The lemonade source build deliberately doesn't bundle backend `llama-server` / `whisper-server` / `sd-server` binaries — it expects host-provided paths. The module exports the matching env vars from the `lemond` service `Environment` and the user session, then lemonade migrates them into `~/.cache/lemonade/config.json`:
+The lemonade source build deliberately doesn't bundle backend `llama-server` / `whisper-server` / `sd-server` binaries — it expects host-provided paths. The module exports the matching env vars from the `lemond` service `Environment` and the user session, then lemonade migrates them into `~/.config/lemonade/config.json`:
 
 | Flag | What gets wired |
 |---|---|
@@ -196,7 +196,7 @@ If `lemonade backends` reports a backend as `installed` but benchmarks report <5
 
 ### Runtime config: `lemonade.settings`
 
-`LEMONADE_DEFAULTS_PATH` only seeds `~/.cache/lemonade/config.json` on lemond's
+`LEMONADE_DEFAULTS_PATH` only seeds `~/.config/lemonade/config.json` on lemond's
 **first** run — afterwards `ConfigFile::load` merges the packaged defaults
 *under* the persisted file, so every key the module declares goes inert. Backend
 bin paths survived that because they point at stable `/etc/lemonade/backends/*`
@@ -207,6 +207,12 @@ budget and turns into zero poll attempts ([#68](https://github.com/noamsto/nix-a
 The lemond unit therefore re-applies the module-declared keys on every start,
 leaving everything else to whatever the web UI persisted. `lemonade.settings`
 rides the same path for keys the module has no dedicated option for:
+
+> **Moved in lemonade 11.8.0:** `config.json` lives in the *config* dir
+> (`$XDG_CONFIG_HOME/lemonade`, falling back to `~/.config/lemonade`), not the
+> cache dir. lemond migrates an existing `~/.cache/lemonade/config.json` on
+> first start — content is preserved and the old copy removed — so nothing is
+> lost on upgrade. The cache dir still holds downloaded backends and models.
 
 ```nix
 hardware.amd-npu.lemonade.settings = {
@@ -337,13 +343,13 @@ ignores the nix-provided `flm`, marks the NPU backend `installable`/"not
 installed", and lists no FLM models even after `flm pull`. The module now seeds
 `flm.prefer_system = true` (with `enableFastFlowLM`), so fresh installs work.
 
-A **cached `~/.cache/lemonade/config.json` wins over that seed** (lemonade merges
+A **cached `~/.config/lemonade/config.json` wins over that seed** (lemonade merges
 user config over defaults), so hosts that ran an older lemonade keep the stale
 `prefer_system: false`. Fix an existing host once, after rebuilding, by deleting
 the cached config so the module's defaults reseed it:
 
 ```bash
-rm ~/.cache/lemonade/config.json
+rm ~/.config/lemonade/config.json
 sudo systemctl restart lemond
 ```
 

--- a/flake.lock
+++ b/flake.lock
@@ -56,11 +56,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1786106723,
-        "narHash": "sha256-zDSUbpoeo/9ZmD2+wXnzxoo1+uhL8vxc0b8yuYMKYq0=",
+        "lastModified": 1787736819,
+        "narHash": "sha256-cV5xEJJK3BvhU8rEd4mC9UsmDi5qscv/kzGPhBRC5WA=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "f13ff45afd1bb73e640eaa08a7066dbed07e3238",
+        "rev": "9fbb54b33e91ee4ca368e35a78e0613c720600b3",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -450,8 +450,8 @@
                 # direction — a broken jq expression would otherwise ship green.
                 reconcile=$(sed -n 's/^ExecStartPre=//p' "$unit"/lemond.service)
                 export HOME=$TMPDIR/home
-                mkdir -p "$HOME/.cache/lemonade"
-                cfg=$HOME/.cache/lemonade/config.json
+                mkdir -p "$HOME/.config/lemonade"
+                cfg=$HOME/.config/lemonade/config.json
                 echo '{"host":"0.0.0.0","max_loaded_models":1,"llamacpp":{"args":"--stale"}}' >"$cfg"
                 chmod 600 "$cfg"
                 "$reconcile"
@@ -542,7 +542,7 @@
                   systemd.services.lemond.wantedBy = lib.mkForce [];
                 };
                 testScript = ''
-                  cfg = "/home/tester/.cache/lemonade/config.json"
+                  cfg = "/home/tester/.config/lemonade/config.json"
 
                   machine.wait_for_unit("multi-user.target")
 
@@ -551,13 +551,13 @@
                   # user-only key is ctx_size rather than host/port because lemond
                   # persists those two from its own flags after the hook has run
                   # (main.cpp:82-99), so they would prove nothing here.
-                  machine.succeed("mkdir -p /home/tester/.cache/lemonade")
+                  machine.succeed("mkdir -p /home/tester/.config/lemonade")
                   machine.succeed(
                       "printf '%s' "
                       "'{\"ctx_size\":8192,\"max_loaded_models\":1,\"llamacpp\":{\"args\":\"--stale\"}}'"
                       " > " + cfg
                   )
-                  machine.succeed("chown -R tester:users /home/tester/.cache")
+                  machine.succeed("chown -R tester:users /home/tester/.config")
 
                   machine.succeed("systemctl start lemond")
                   machine.wait_for_unit("lemond.service")

--- a/modules/amd-npu.nix
+++ b/modules/amd-npu.nix
@@ -125,7 +125,12 @@
     name = "lemond-reconcile-config";
     runtimeInputs = [pkgs.jq pkgs.coreutils];
     text = ''
-      config="''${LEMONADE_CACHE_DIR:-''${HOME:-}/.cache/lemonade}/config.json"
+      # 11.8.0 moved config.json out of the cache dir: ConfigFile::load reads it
+      # only from config_dir, which lemond resolves as
+      # $XDG_CONFIG_HOME/lemonade with a $HOME/.config fallback. Reconciling the
+      # old cache path writes a file nothing reads, and module keys go inert the
+      # moment lemond persists anything of its own.
+      config="''${XDG_CONFIG_HOME:-''${HOME:-}/.config}/lemonade/config.json"
       [ -f "$config" ] || exit 0
 
       tmp="$config.nix-reconcile"
@@ -285,7 +290,7 @@ in {
 
           These keys are re-applied on every `lemond` start, so they stay
           declarative; keys not listed here are left to whatever the web UI
-          persisted in `''${LEMONADE_CACHE_DIR:-~/.cache/lemonade}/config.json`.
+          persisted in `''${XDG_CONFIG_HOME:-~/.config}/lemonade/config.json`.
         '';
       };
 

--- a/pkgs/fastflowlm/default.nix
+++ b/pkgs/fastflowlm/default.nix
@@ -22,13 +22,13 @@
 }:
 stdenv.mkDerivation (finalAttrs: {
   pname = "fastflowlm";
-  version = "0.9.46";
+  version = "1.0.3";
 
   src = fetchFromGitHub {
-    owner = "FastFlowLM";
+    owner = "ROCm";
     repo = "FastFlowLM";
     rev = "v${finalAttrs.version}";
-    hash = "sha256-e8lDEW6pMaypLj3+VcEfX2EtsFhxu1IsF8xPm/n0SX4=";
+    hash = "sha256-d9YbAruZ1LdfoK+/M4IQe4/9ejYCuNVVxahEKHspYBw=";
     fetchSubmodules = true;
   };
 
@@ -65,12 +65,6 @@ stdenv.mkDerivation (finalAttrs: {
   postPatch = ''
     # Cargo.lock is not committed upstream; inject our copy
     cp ${./Cargo.lock} third_party/tokenizers-cpp/rust/Cargo.lock
-
-    # Remove the attempt to create /usr/local/bin symlink at install time
-    substituteInPlace src/CMakeLists.txt \
-      --replace-fail \
-        'NOT CMAKE_INSTALL_PREFIX STREQUAL "/usr" AND NOT CMAKE_INSTALL_PREFIX STREQUAL "/usr/local"' \
-        'FALSE'
   '';
 
   dontUseCmakeConfigure = true;

--- a/pkgs/lemonade/darwin.nix
+++ b/pkgs/lemonade/darwin.nix
@@ -15,7 +15,7 @@ in
     # user cache at first run, exactly as the official .pkg does.
     src = fetchurl {
       url = "https://github.com/lemonade-sdk/lemonade/releases/download/v${version}/lemonade-embeddable-${version}-macos-arm64.tar.gz";
-      hash = "sha256-64fW+j6Sv9MVisTV5Zd1Vas2Otozo6tm9VbwtLqCgNY=";
+      hash = "sha256-RyqpaykN2ztJULAoFRAgqsH4OOWfMrNHz6ChXitXPLU=";
     };
 
     # The Mach-O binaries are adhoc-signed and link only against system

--- a/pkgs/lemonade/default.nix
+++ b/pkgs/lemonade/default.nix
@@ -39,7 +39,7 @@
     owner = "lemonade-sdk";
     repo = "lemonade";
     rev = "v${version}";
-    hash = "sha256-vt1BFdNKpM6OM15jatxJbBduClibKdbcON9AGcZ0Rtc=";
+    hash = "sha256-n6h4LbWUUyxv2e99gCB2hjx8bEMtiMK4kpTtUxKQGbc=";
   };
 
   web-app = callPackage ./web-app.nix {inherit src version;};
@@ -94,12 +94,14 @@ in stdenv.mkDerivation {
     # singular/plural tolerant: v10.8.1 pluralized the comment ("symlinks ... search paths").
     sed -i '/Create symlinks\? in standard systemd search paths\? only if not installing to/,/^    endif()$/d' CMakeLists.txt
 
-    # secrets.conf install rule writes to absolute /etc/lemonade/conf.d. The
-    # NixOS module is what owns /etc, not us — relocate the template under
-    # $out so it ships with the derivation but doesn't try to populate /etc.
+    # secrets.conf install rule writes to an absolute /etc path (11.8.0 moved it
+    # from /etc/lemonade/conf.d to /etc/default, loaded via
+    # EnvironmentFile=-/etc/default/lemond). The NixOS module is what owns /etc,
+    # not us — relocate the template under $out so it ships with the derivation
+    # but doesn't try to populate /etc.
     substituteInPlace CMakeLists.txt \
       --replace-fail \
-        'DESTINATION /etc/lemonade/conf.d' \
+        'DESTINATION /etc/default' \
         'DESTINATION share/lemonade/conf.d.example'
 
     # Let a packager point lemonade at a defaults.json outside the FHS path.

--- a/pkgs/lemonade/version.nix
+++ b/pkgs/lemonade/version.nix
@@ -2,4 +2,4 @@
 # build (default.nix) and the macOS prebuilt wrap (darwin.nix). The update
 # workflow (scripts/bump-versions.sh) bumps this file and refreshes both the
 # source-tarball hash (default.nix) and the embeddable-bundle hash (darwin.nix).
-"11.5.2"
+"11.8.1"


### PR DESCRIPTION
Supersedes **#91** (11.6.0 / FLM 1.0.1) and **#92** (11.7.0 / FLM 1.0.2), both of which were stale before anyone could review them, and carries @puffnfresh's fastflowlm change from **#93**, which was stuck targeting #92's branch.

| | before | after |
|---|---|---|
| lemonade | 11.5.2 | **11.8.1** |
| fastflowlm | 0.9.46 | **1.0.3** |
| nixpkgs | `f13ff45` (2026-08-07) | `9fbb54b` (2026-08-26) |

Neither of these was a version-string change — both upstreams moved something the packaging depends on, and both broke the build.

### FastFlowLM moved org, and dropped the block we were patching

FLM 1.0.0 was its "first release under the ROCm org": the repo is now `ROCm/FastFlowLM`, so `owner` moves with it rather than riding GitHub's redirect.

1.0.0 also removed the CMake block that symlinks into `/usr/local`, so our `--replace-fail` had nothing to match and **failed the build**. Removing that `postPatch` is exactly @puffnfresh's #93 — credited in the commit. Verified directly against upstream: the block is present at `v0.9.46` (`src/CMakeLists.txt:794`) and absent at `v1.0.3`.

### Lemonade 11.8.0 moved the secrets template

The patch that keeps `secrets.conf` out of `/etc` targeted `DESTINATION /etc/lemonade/conf.d`. 11.8.0 moved it to `/etc/default` (`RENAME lemond`, loaded via `EnvironmentFile=-/etc/default/lemond`), so `--replace-fail` failed:

```
substituteStream() in derivation lemonade-11.8.1: ERROR: pattern
DESTINATION\ /etc/lemonade/conf.d doesn't match anything in file 'CMakeLists.txt'
```

Retargeted to `DESTINATION /etc/default` (confirmed unique in 11.8.1's CMakeLists). The other three `--replace-fail` patches — `config_file.cpp`, `server.cpp`, `backend_manager.cpp` — still apply unchanged.

### vllm-rocm deliberately left alone

#92 tried to bump it and produced a corrupt result: gfx1150 got gfx1151's hashes against a 404 URL, gfx1151 got `hash = ""`. That's a bug in `scripts/check-updates.sh`, fixed in **#95**. Once #95 lands, the weekly workflow bumps vllm correctly on its own — no reason to hand-fetch 8 GB here.

### Verification

- `nix build .#lemonade` and `nix build .#fastflowlm` both succeed.
- Binaries report `lemonade version 11.8.1` and `FLM v1.0.3`.
- `backend_versions.json` correctly rewritten to `flm.npu = v1.0.3`, over upstream's `v1.0.2`.
- Secrets template lands at `$out/share/lemonade/conf.d.example/lemond` — out of `/etc`, as intended.
- fastflowlm's `auto-patchelf: 0 dependencies could not be satisfied`; it now ships `libqwen3_5vl_npu.so` and `libqwen3_6_moe_npu.so`.
- `nix flake check --no-build` green.

Not tested: NPU or GPU inference — no hardware run in this PR.

### ⚠️ Weights update required for FLM users

1.0.2 and 1.0.3 re-quantized the **Qwen3.5 family and Qwen3.6-MoE** from Q4_1 to Q4_K. Existing local copies are **not compatible** and must be re-pulled:

```bash
flm pull qwen3.5:0.8b
flm pull qwen3.5:2b
flm pull qwen3.5:4b
flm pull qwen3.5:9b
flm pull qwen3.6-moe:35b-a3b
```

Once this merges, #91, #92 and #93 can all be closed as superseded.
