### PR TITLE
docs: record contributor attribution and inline-credit conventions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,55 @@
+# Repo conventions
+
+## Credit carried patches with `Co-authored-by:`
+
+When a commit carries someone else's work — their patch, their fix, their
+measurements — add a trailer:
+
+```
+Co-authored-by: Their Name <their@email>
+```
+
+Take the name and email verbatim from their commit (`git log --format='%an <%ae>'`
+on their branch) or from the PR's commit list. A trailer that doesn't match a
+GitHub account is silently ignored.
+
+**The trailer must be in a commit message on the branch, not the PR body.** This
+repo is squash-only with `squash_message = COMMIT_MESSAGES`, so the squash
+commit body is assembled from branch commit messages; anything written only in
+the PR description is dropped on merge.
+
+**Why:** GitHub counts co-authors in the contributors graph and on their profile.
+Prose credit in a commit body reads fine and counts for nothing. This repo's most
+valuable contributions arrive as measurements and diagnosis in issue threads
+rather than as commits, so the graph already undercounts them badly — a trailer
+is the one form of credit that is permanent and needs no upkeep.
+
+This exists because it was got wrong: #98 carried @puffnfresh's fastflowlm fix
+from #93, credited it in prose, and shipped him invisible.
+
+The case to watch for is a contributor PR that can't be merged as-is — targeted
+at a stale branch, or superseded by a rewrite. Carrying the change by hand is
+often right; dropping the attribution with it is not.
+
+## Don't add a credits section to the README
+
+Credit at the point of use instead, next to the data it belongs to:
+
+```markdown
+Halo measurements above contributed by [@expelledboy](https://github.com/expelledboy) (#42).
+```
+
+Inline credit lives inside the unit that gets rewritten, so it is updated or
+deleted along with the claim it describes and cannot drift out of sync. A
+standalone credits table has the opposite property: it needs a manual edit per
+contributor, and it goes *actively wrong* when a figure is re-measured by someone
+else — a misattributed measurement is worse than an unattributed one.
+
+## Hardware-gated claims
+
+Numbers in this repo are hardware-specific and rarely transfer. Say which host a
+measurement came from, and don't reuse a conclusion across GPU targets: rocWMMA
+is a net regression on gfx1150 and expected to win on gfx1151.
+
+When a claim hasn't been measured, say so rather than naming a plausible cause.
+`docs/halo-bringup-checklist.md` tracks what is still hardware-gated.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md


### PR DESCRIPTION
Adds `AGENTS.md` (symlinked as `CLAUDE.md`) with three repo conventions. The first exists because it was got wrong, in this repo, last week.

### The attribution rule

#98 carried @puffnfresh's fastflowlm fix from #93 — his PR targeted a bot branch that had to be abandoned, so the change was applied by hand — and credited him **in prose** in the commit body. GitHub counts `Co-authored-by:` trailers, not prose, so his fix is in `main` right now with him showing **zero commits** in the contributors graph.

The mechanical detail that makes this actionable, and that I'd otherwise have got wrong again:

```
$ gh api repos/noamsto/nix-amd-ai --jq '{squash_message}'
{"squash_message":"COMMIT_MESSAGES"}
```

This repo is squash-only and builds the squash body from **commit messages**, not the PR description. So a `Co-authored-by:` line written only in a PR body is silently dropped at merge — it has to be on a branch commit.

The case to watch for is exactly the one that bit us: a contributor PR that can't be merged as-is, because it targets a stale branch or gets superseded by a rewrite. Carrying the change by hand is often the right call; dropping the attribution along with the branch is not.

### Why no README credits section

@noamsto asked whether the README should get a credits section, and the honest answer was no — I'd proposed one and it was the *least* maintainable option on the table. That reasoning is worth keeping rather than rediscovering:

Inline credit — like the existing line under the Halo `gpuMemory` data — lives **inside the unit that gets rewritten**. When the data is replaced, the credit is replaced or deleted with it. It structurally cannot drift out of sync.

A standalone credits table has the opposite property: a manual edit per contributor with nothing enforcing it, and it goes **actively wrong** when a figure is re-measured by someone else. A misattributed measurement is worse than an unattributed one. It also creates an asymmetric obligation — nobody notices when it's right, everyone notices when they're missing.

### Hardware gating

Third entry carries forward what the Halo work kept running into: don't reuse a conclusion across GPU targets (rocWMMA is a net regression on gfx1150 and expected to *win* on gfx1151), and don't name a cause you haven't measured — the mistake corrected in #94, where an 8-column explanation contradicted this README's own line 123.

### Note on scope

This does **not** retroactively fix puffnfresh's attribution. `main`'s history is squashed and merged; rewriting it for one trailer isn't worth it. I offered on #93 to rebase his patch as his own commit and re-do the bump on top — that offer stands and is the only clean remedy.

No `CONTRIBUTING.md`: the failure mode here is a maintainer carrying a patch mid-bump, not an external contributor opening a PR, so the guidance belongs where that work happens.
