### PR TITLE
feat(lemonade): add cacheDir to relocate model caches off $HOME

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -167,6 +167,33 @@
             ];
           }).config.systemd.units."lemond.service".unit;
 
+        # Same host as lemondUnit but with lemonade.cacheDir set — consumed by
+        # the lemond-cachedir-unit-render check.
+        lemondCacheDirUnit =
+          (inputs.nixpkgs.lib.nixosSystem {
+            inherit system;
+            modules = [
+              inputs.self.nixosModules.default
+              {
+                boot.loader.grub.enable = false;
+                fileSystems."/" = {
+                  device = "/dev/sda1";
+                  fsType = "ext4";
+                };
+                hardware.amd-npu = {
+                  enable = true;
+                  enableLemonade = true;
+                  lemonade.user = "testuser";
+                  lemonade.cacheDir = "/var/lib/models";
+                };
+                users.users.testuser = {
+                  isNormalUser = true;
+                  extraGroups = ["video" "render"];
+                };
+              }
+            ];
+          }).config.systemd.units."lemond.service".unit;
+
         # Rendered ds4-server.service for a minimal ds4.enable host — consumed by
         # the ds4-server-unit-render check.
         ds4ServerUnit =
@@ -264,6 +291,18 @@
                   }
                 ];
               }).config.system.build.etc;
+
+            # cacheDir must put both caches on the given root: HF_HOME gains the
+            # /hf suffix (lemonade appends hub/ itself) and LEMONADE_CACHE_DIR the
+            # /lemonade one. The absence case is asserted in lemond-unit-render.
+            lemond-cachedir-unit-render = pkgs.runCommand "lemond-cachedir-unit-render" {} ''
+              unit=${lemondCacheDirUnit}/lemond.service
+              grep -q 'HF_HOME=/var/lib/models/hf' "$unit" \
+                || { echo "missing/changed HF_HOME"; exit 1; }
+              grep -q 'LEMONADE_CACHE_DIR=/var/lib/models/lemonade' "$unit" \
+                || { echo "missing/changed LEMONADE_CACHE_DIR"; exit 1; }
+              touch $out
+            '';
 
             module-eval-vulkan-true =
               (inputs.nixpkgs.lib.nixosSystem {
@@ -696,6 +735,8 @@
                 || { echo "missing/changed NIX_LD_LIBRARY_PATH"; exit 1; }
               ! grep -q 'LEMONADE_ALLOWED_ORIGINS' "$unit" \
                 || { echo "LEMONADE_ALLOWED_ORIGINS set on a host that never listed origins"; exit 1; }
+              ! grep -qE 'HF_HOME|LEMONADE_CACHE_DIR' "$unit" \
+                || { echo "cache env set on a host that never set cacheDir"; exit 1; }
               touch $out
             '';
 

--- a/modules/amd-npu.nix
+++ b/modules/amd-npu.nix
@@ -299,6 +299,31 @@ in {
         description = "User account to run the Lemonade server as.";
       };
 
+      cacheDir = mkOption {
+        type = types.nullOr types.str;
+        default = null;
+        example = "/var/lib/models";
+        description = ''
+          Root for lemond's two model caches, relocating them off the service
+          user's home: `HF_HOME` becomes `''${cacheDir}/hf` (weights land in
+          `hf/hub`, per the Hugging Face convention lemonade's `models_dir =
+          "auto"` follows) and `LEMONADE_CACHE_DIR` becomes
+          `''${cacheDir}/lemonade`.
+
+          Worth setting on any host with storage tuned for weights, because
+          both caches get large — 147 GB and 9.9 GB respectively on a host that
+          has been serving for a while — and `$HOME` is rarely the subvolume you
+          want them on.
+
+          A runtime path, deliberately a string so it is not copied into the Nix
+          store. The `hf` and `lemonade` subdirectories must exist and be
+          writable by `user`; the unit does not create them, since this is
+          typically a mountpoint the host manages.
+
+          Setting `settings.models_dir` explicitly overrides the `HF_HOME` half.
+        '';
+      };
+
       desktopApp.enable = mkOption {
         type = types.bool;
         default = true;
@@ -660,6 +685,10 @@ in {
           # them, so koko's loader can't find them without re-exporting here.
           NIX_LD = config.environment.sessionVariables.NIX_LD;
           NIX_LD_LIBRARY_PATH = config.environment.sessionVariables.NIX_LD_LIBRARY_PATH;
+        }
+        // optionalAttrs (cfg.lemonade.cacheDir != null) {
+          HF_HOME = "${cfg.lemonade.cacheDir}/hf";
+          LEMONADE_CACHE_DIR = "${cfg.lemonade.cacheDir}/lemonade";
         }
         // optionalAttrs (cfg.lemonade.allowedOrigins != []) {
           # env-only in lemonade >=11.5.0 — no config.json key to route this


### PR DESCRIPTION
`lemond` runs as a normal user and inherits the default cache locations, so weights accumulate in the service user's home regardless of how the host's storage is laid out. On g6 that is currently **147 GB in `~/.cache/huggingface` plus 9.9 GB in `~/.cache/lemonade`** — awkward when `$HOME` is a compressed, copy-on-write subvolume and a dedicated uncompressed/nodatacow one exists for exactly this.

```nix
hardware.amd-npu.lemonade.cacheDir = "/var/lib/models";
```

sets `HF_HOME=/var/lib/models/hf` and `LEMONADE_CACHE_DIR=/var/lib/models/lemonade` on the unit.

### Env var names are verified, not assumed

- `LEMONADE_CACHE_DIR` — read in `src/cpp/server/utils/path_utils.cpp:172` (`get_cache_dir()`), ahead of the platform default.
- `HF_HOME` — `models_dir` defaults to `"auto"`, which follows `HF_HUB_CACHE` / `HF_HOME` (`docs/embeddable/models.md:25`). Weights land in `$HF_HOME/hub`, hence the `/hf` suffix rather than pointing `HF_HOME` at the root.

Typed as a string rather than a path, matching `ds4.model`, so a multi-GB cache root is never copied into the store. The unit does not create the subdirectories — it is typically a mountpoint the host manages — and the option documents that.

### Tests

Both directions, following the `LEMONADE_ALLOWED_ORIGINS` pattern already in `lemond-unit-render`:

- `lemond-cachedir-unit-render` (new) — asserts both vars render with the correct suffixes.
- `lemond-unit-render` — gains a negative assertion that neither var appears when `cacheDir` is unset.

The negative assertion was mutation-tested: setting `cacheDir` on the default host makes it fail with `cache env set on a host that never set cacheDir`. `nix flake check` is green.

### Context

Found while bringing up halo (Strix Halo / gfx1151) as a serving host — its `@models` subvolume is uncompressed + nodatacow specifically for weights, and without this the subvolume stays empty while everything lands on `@home`. g6 can use the same option to move its 157 GB.

https://claude.ai/code/session_01W17AmgaCY78k2yp7BrMPmv