### PR TITLE
fix(ds4): skip the unit when the model file is absent

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -820,6 +820,8 @@
               grep -q 'SupplementaryGroups=video' "$unit" || { echo "missing video group"; exit 1; }
               grep -q 'SupplementaryGroups=render' "$unit" || { echo "missing render group"; exit 1; }
               grep -q 'StateDirectory=ds4' "$unit" || { echo "missing StateDirectory"; exit 1; }
+              grep -q 'ConditionPathExists=/var/lib/ds4/DeepSeek-V4-Flash.gguf' "$unit" \
+                || { echo "missing ConditionPathExists on the model"; exit 1; }
               touch $out
             '';
 

--- a/modules/amd-npu.nix
+++ b/modules/amd-npu.nix
@@ -512,8 +512,9 @@ in {
       user = mkOption {
         type = types.str;
         description = ''
-          User account to run ds4-server as. Must be in the `render` and
-          `video` groups for ROCm GPU access.
+          User account to run ds4-server as. Needs no group setup: the unit
+          grants `render` and `video` itself via `SupplementaryGroups`, unlike
+          lemond, whose `user` must be in them already.
         '';
       };
 
@@ -786,6 +787,13 @@ in {
       # Declared on one side only: systemd derives the inverse, so starting
       # either unit stops the other.
       conflicts = optional (cfg.exclusiveInference && cfg.enableLemonade) "lemond.service";
+      # Nothing provisions ds4.model - lemonade.models has its reconcile units,
+      # this has no equivalent - so an absent GGUF is the expected first-boot
+      # state on a new host. Without this the unit retries forever: RestartSec=5s
+      # against systemd's default 5-starts-per-10s limiter never trips it, so it
+      # spins silently rather than failing. The condition makes systemd skip it
+      # and say why.
+      unitConfig.ConditionPathExists = cfg.ds4.model;
       serviceConfig = {
         Type = "simple";
         User = cfg.ds4.user;


### PR DESCRIPTION
Nothing provisions `ds4.model`. `lemonade.models` has its `lemond-models` reconcile unit; `ds4` has no equivalent, so an absent GGUF is the *expected* state on a host that has just set `ds4.enable`.

Today that fails badly. The unit has `Restart=on-failure` with `RestartSec=5s` and no `StartLimit*`, so systemd's defaults apply — 5 starts per 10 s. At one start every 5 s only two land in any window, so **the limiter never trips and the unit retries forever**, logging only the engine's own error. `ConditionPathExists` makes systemd skip it cleanly and say why.

```nix
unitConfig.ConditionPathExists = cfg.ds4.model;
```

### What this does not fix

It catches *absent*, not *incomplete*. A half-downloaded GGUF passes the condition and still fails inside the engine — which is exactly the state a host is in while the 80 GiB file streams down. Closing that properly needs a size/checksum check or a real provisioning unit wrapping upstream's `download_model.sh`; that's a bigger design question and deliberately not attempted here.

### Also

`ds4.user`'s description told the reader the account "must be in the `render` and `video` groups", but the unit already grants both via `SupplementaryGroups`. `lemond` is the one whose `user` genuinely needs them, so the docs sent people to do unnecessary work on the wrong service. Corrected to say so.

### Tests

Extended the existing `ds4-server-unit-render` check with a `ConditionPathExists` assertion, added red-first (it failed with `missing ConditionPathExists on the model` before the fix). `nix flake check` is green.

### Context

Found bringing up halo (Strix Halo / gfx1151) as a ds4 host — see noamsto/nix-config#197.

https://claude.ai/code/session_01W17AmgaCY78k2yp7BrMPmv