### PR TITLE
feat(module): add autoStart and exclusiveInference for the inference servers

### DIFF
--- a/README.md
+++ b/README.md
@@ -525,6 +525,21 @@ The concurrency row is the interesting one: an NPU workload running alongside an
 
 Enable all three and let lemonade pick the recipe per model.
 
+### Running ds4 beside lemond
+
+Both servers draw from the same GTT pool, and a DeepSeek-V4-Flash-sized model leaves no room for a second resident one. Measured on a 128 GB Strix Halo (gfx1151) at `ttmSizeGiB = 104`: the 80.76 GiB `IQ2XXS-w2Q2K` quant answers in 1.3 s with ds4 alone, but with a 4B model also loaded under lemond there is nothing left for page cache — lemond fell from 53 tok/s to 0.11 (71 s to process 8 prompt tokens), and shortly after that *both* endpoints stopped answering. Stopping either one restores the other immediately.
+
+`exclusiveInference` makes that explicit instead of leaving the machine to thrash, and `autoStart` picks which server the host boots with:
+
+```nix
+hardware.amd-npu = {
+  exclusiveInference = true;   # Conflicts=: starting either stops the other
+  ds4.autoStart = false;       # boot into lemond, run ds4 on demand
+};
+```
+
+`systemctl start ds4-server` then stops lemond, and `systemctl start lemond` stops ds4. Both options default to the previous behaviour — every server autostarts, nothing conflicts — so this is opt-in for hosts where the models genuinely don't fit together. On a box with headroom for both, leave it off.
+
 ## Coding agents and client timeouts
 
 Coding agents (Claude Code, opencode) ship large system prompts — 10k+ tokens once MCP servers, skills, and tool schemas are loaded. On a Strix Point iGPU, prompt processing runs at ~350 t/s, so the agent's first turn spends 25–35 s before the first token is emitted. Neither lemonade nor the agents send SSE keep-alive events during that silent window, and most clients close the socket after ~30 s, yielding:

--- a/flake.nix
+++ b/flake.nix
@@ -599,6 +599,74 @@
                 touch $out
               '';
 
+            module-eval-server-autostart = let
+              mkSys = npuExtra:
+                (inputs.nixpkgs.lib.nixosSystem {
+                  inherit system;
+                  modules = [
+                    inputs.self.nixosModules.default
+                    {
+                      boot.loader.grub.enable = false;
+                      fileSystems."/" = {
+                        device = "/dev/sda1";
+                        fsType = "ext4";
+                      };
+                      # recursiveUpdate, not //: npuExtra overrides a single
+                      # nested key like ds4.autoStart without dropping the
+                      # enable/user/model siblings beside it.
+                      hardware.amd-npu = inputs.nixpkgs.lib.recursiveUpdate {
+                        enable = true;
+                        enableLemonade = true;
+                        lemonade = {
+                          user = "testuser";
+                          models = ["Qwen3.5-4B-MTP-GGUF"];
+                        };
+                        ds4 = {
+                          enable = true;
+                          user = "testuser";
+                          model = "/var/lib/ds4/model.gguf";
+                        };
+                      }
+                      npuExtra;
+                      users.users.testuser = {
+                        isNormalUser = true;
+                        extraGroups = ["video" "render"];
+                      };
+                    }
+                  ];
+                }).config;
+              defaults = mkSys {};
+              exclusive = mkSys {
+                exclusiveInference = true;
+                ds4.autoStart = false;
+              };
+              lemonadeOff = mkSys {lemonade.autoStart = false;};
+            in
+              pkgs.runCommand "module-eval-server-autostart" {
+                dsDefault = defaults.systemd.units."ds4-server.service".unit;
+                dsExclusive = exclusive.systemd.units."ds4-server.service".unit;
+                lemondDefault = defaults.systemd.units."lemond.service".unit;
+                lemondOff = lemonadeOff.systemd.units."lemond.service".unit;
+                modelsOff = lemonadeOff.systemd.units."lemond-models.service".unit;
+              } ''
+                # Defaults unchanged: both servers still come up at boot and
+                # nothing conflicts, so existing hosts see no behaviour change.
+                grep -qF 'WantedBy=multi-user.target' "$dsDefault"/ds4-server.service
+                grep -qF 'WantedBy=multi-user.target' "$lemondDefault"/lemond.service
+                ! grep -qF 'Conflicts=lemond.service' "$dsDefault"/ds4-server.service
+
+                # autoStart=false leaves the unit built but out of every target.
+                ! grep -qF 'WantedBy=multi-user.target' "$dsExclusive"/ds4-server.service
+                grep -qF 'Conflicts=lemond.service' "$dsExclusive"/ds4-server.service
+
+                # lemond-models has Requires=lemond, so it has to leave the boot
+                # target too — otherwise it drags lemond back up behind autoStart.
+                ! grep -qF 'WantedBy=multi-user.target' "$lemondOff"/lemond.service
+                ! grep -qF 'WantedBy=multi-user.target' "$modelsOff"/lemond-models.service
+
+                touch $out
+              '';
+
             # The checks above prove the unit renders and that the hook behaves
             # when invoked by hand. This one boots it: lemond must actually reach
             # active with the ExecStartPre in front of it. That is the failure
@@ -615,7 +683,6 @@
             .testers.runNixOSTest {
                 name = "lemond-reconcile";
                 nodes.machine = {
-                  lib,
                   pkgs,
                   ...
                 }: {
@@ -631,13 +698,13 @@
                     lemonade = {
                       user = "tester";
                       settings.max_loaded_models = -1;
+                      # Hold lemond back so the stale config is in place before
+                      # its first start; left to boot it would seed a fresh
+                      # config, the one path that never exercises reconciliation.
+                      autoStart = false;
                     };
                   };
                   users.users.tester.isNormalUser = true;
-                  # Hold lemond back so the stale config is in place before its
-                  # first start; left to boot it would seed a fresh config, the one
-                  # path that never exercises reconciliation.
-                  systemd.services.lemond.wantedBy = lib.mkForce [];
                 };
                 testScript = ''
                   cfg = "/home/tester/.config/lemonade/config.json"

--- a/modules/amd-npu.nix
+++ b/modules/amd-npu.nix
@@ -281,7 +281,42 @@ in {
       '';
     };
 
+    exclusiveInference = mkOption {
+      type = types.bool;
+      default = false;
+      description = ''
+        Make `lemond` and `ds4-server` mutually exclusive: starting either one
+        stops the other, via systemd `Conflicts=`. No-op unless both are
+        enabled.
+
+        Off by default, because whether the two fit side by side is a property
+        of the host rather than of the module — the sum of their resident models
+        against physical RAM and the GTT pool they both draw from. Turn it on
+        where they do not fit. Measured on a 128 GB Strix Halo at
+        `ttmSizeGiB = 104`: an 80.76 GiB DeepSeek-V4-Flash under ds4 answers in
+        1.3 s on its own, but with a 4B model also resident under lemond there
+        is nothing left for page cache — lemond fell from 53 tok/s to 0.11, and
+        then both endpoints stopped answering. Stopping either restores the
+        other immediately.
+
+        Pair it with `autoStart` to choose which server owns the box at boot.
+      '';
+    };
+
     lemonade = {
+      autoStart = mkOption {
+        type = types.bool;
+        default = true;
+        description = ''
+          Whether `lemond` (and the `lemond-models` puller, which requires it)
+          start at boot.
+
+          Set false to leave lemond built and available but idle, started on
+          demand with `systemctl start lemond`. Useful with
+          `exclusiveInference`, where only one server can own the box.
+        '';
+      };
+
       port = mkOption {
         type = types.port;
         default = 13305;
@@ -421,6 +456,19 @@ in {
 
     ds4 = {
       enable = mkEnableOption "the ds4-server DeepSeek V4 inference server as a systemd unit";
+
+      autoStart = mkOption {
+        type = types.bool;
+        default = true;
+        description = ''
+          Whether `ds4-server` starts at boot.
+
+          Set false on a host where ds4 serves a model too large to keep
+          resident all the time — the unit stays built and startable with
+          `systemctl start ds4-server`, but the machine comes up without 80+
+          GiB of weights loaded. See `exclusiveInference`.
+        '';
+      };
 
       package = mkOption {
         type = types.package;
@@ -654,7 +702,7 @@ in {
       description = "Lemonade AI Server";
       after = ["network-online.target"];
       wants = ["network-online.target"];
-      wantedBy = ["multi-user.target"];
+      wantedBy = optional cfg.lemonade.autoStart "multi-user.target";
       path = pathList ++ ["/run/current-system/sw"];
       environment =
         {
@@ -716,7 +764,8 @@ in {
       description = "Reconcile downloaded lemonade models";
       after = ["lemond.service"];
       requires = ["lemond.service"];
-      wantedBy = ["multi-user.target"];
+      # Requires= would otherwise pull lemond back up at boot behind autoStart.
+      wantedBy = optional cfg.lemonade.autoStart "multi-user.target";
       serviceConfig = {
         Type = "simple";
         User = cfg.lemonade.user;
@@ -733,7 +782,10 @@ in {
       description = "ds4 DeepSeek V4 inference server";
       after = ["network-online.target"];
       wants = ["network-online.target"];
-      wantedBy = ["multi-user.target"];
+      wantedBy = optional cfg.ds4.autoStart "multi-user.target";
+      # Declared on one side only: systemd derives the inverse, so starting
+      # either unit stops the other.
+      conflicts = optional (cfg.exclusiveInference && cfg.enableLemonade) "lemond.service";
       serviceConfig = {
         Type = "simple";
         User = cfg.ds4.user;


### PR DESCRIPTION
Both `lemond` and `ds4-server` hardcode `wantedBy = ["multi-user.target"]`, so a host that cannot run the two side by side has no module-level way to say so. The workaround is reaching into the generated units from the host config:

```nix
systemd.services.ds4-server = {
  wantedBy = lib.mkForce [];
  conflicts = ["lemond.service"];
};
```

This repo's own `lemond-vm` check already carried half of that (`wantedBy = lib.mkForce []`) to hold lemond back before its first start — it now uses the option instead.

## The measurement behind it

On a 128 GB Strix Halo (gfx1151, npu5) at `ttmSizeGiB = 104`, serving the 80.76 GiB `DeepSeek-V4-Flash-IQ2XXS-w2Q2K` quant:

| State | Result |
| --- | --- |
| ds4 alone | completion in **1.3 s** |
| ds4 + a 4B model resident under lemond | lemond drops to **0.11 tok/s** (71 s for 8 prompt tokens, from 53 tok/s), then **both** endpoints time out |
| stop lemond | ds4 back to 1.3 s immediately |

They share the GTT pool, and 80.76 GiB + ~11 GiB of weights leaves nothing for page cache. Which is a property of the host, not of the module — hence an option rather than a default.

## What this adds

- `lemonade.autoStart` (default `true`) — gates `lemond` **and** `lemond-models`. The puller has `Requires=lemond.service`, so leaving it in the boot target would drag lemond back up behind the option.
- `ds4.autoStart` (default `true`)
- `exclusiveInference` (default `false`) — emits `Conflicts=lemond.service` on `ds4-server` when both servers are enabled. Declared on one side only; systemd derives the inverse, so starting either stops the other.

Every default is the existing behaviour, so no host changes on upgrade.

## Verified

New `module-eval-server-autostart` check covers all three: defaults still autostart with no `Conflicts=`, `ds4.autoStart = false` leaves the unit built but out of every target while `exclusiveInference` adds the conflict, and `lemonade.autoStart = false` drops both lemond units from the boot target.

`nix flake check` green, including `lemond-vm` on the rewritten option.

Behaviour also confirmed on the live Halo host (via the equivalent host-level override, before this module change existed):

```
after starting ds4:     lemond inactive, ds4 active
after starting lemond:  lemond active,   ds4 deactivating
```

https://claude.ai/code/session_01SGGVapVMi9yR5Lg7X8yK4L