### PR TITLE
fix(lemonade): name the gpt-oss-120b checkpoint, add declarative custom models

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -503,6 +503,68 @@
                 touch $out
               '';
 
+            # customModels must reach user_models.json even on a host that has no
+            # config.json (nothing else creates that file), must not clobber a
+            # model the web UI registered, and must re-apply a stale entry --
+            # otherwise a declared checkpoint silently rots to whatever lemond
+            # last persisted.
+            module-eval-lemonade-custom-models = let
+              sys =
+                (inputs.nixpkgs.lib.nixosSystem {
+                  inherit system;
+                  modules = [
+                    inputs.self.nixosModules.default
+                    {
+                      boot.loader.grub.enable = false;
+                      fileSystems."/" = {
+                        device = "/dev/sda1";
+                        fsType = "ext4";
+                      };
+                      hardware.amd-npu = {
+                        enable = true;
+                        enableLemonade = true;
+                        lemonade = {
+                          user = "testuser";
+                          customModels."Declared-GGUF" = {
+                            checkpoints.main = "org/repo:declared.gguf";
+                            recipe = "llamacpp";
+                          };
+                        };
+                      };
+                      users.users.testuser = {
+                        isNormalUser = true;
+                        extraGroups = ["video" "render"];
+                      };
+                    }
+                  ];
+                }).config;
+            in
+              pkgs.runCommand "module-eval-lemonade-custom-models" {
+                nativeBuildInputs = [pkgs.jq];
+                unit = sys.systemd.units."lemond.service".unit;
+              } ''
+                reconcile=$(sed -n 's/^ExecStartPre=//p' "$unit"/lemond.service)
+                export HOME=$TMPDIR/home
+                mkdir -p "$HOME/.config/lemonade"
+                models=$HOME/.config/lemonade/user_models.json
+
+                # No config.json and no user_models.json: the reconcile must still
+                # create the latter rather than bailing out early.
+                "$reconcile"
+                jq -e '."Declared-GGUF".checkpoints.main == "org/repo:declared.gguf"' "$models" >/dev/null
+
+                # A UI-registered model survives, and a drifted declared entry is restored.
+                echo '{"UI-GGUF":{"recipe":"llamacpp"},"Declared-GGUF":{"checkpoints":{"main":"org/repo:stale.gguf"}}}' >"$models"
+                chmod 600 "$models"
+                "$reconcile"
+
+                jq -e '."Declared-GGUF".checkpoints.main == "org/repo:declared.gguf"' "$models" >/dev/null
+                jq -e '."UI-GGUF".recipe == "llamacpp"' "$models" >/dev/null
+                [ "$(stat -c %a "$models")" = 600 ]
+
+                touch $out
+              '';
+
             module-eval-lemonade-models = let
               mkSys = lemonadeExtra:
                 (inputs.nixpkgs.lib.nixosSystem {

--- a/modules/amd-npu.nix
+++ b/modules/amd-npu.nix
@@ -118,6 +118,10 @@
     (pkgs.formats.json {}).generate "lemonade-defaults.json"
     (lib.recursiveUpdate lemonadeDefaults cfg.lemonade.settings);
 
+  lemonadeCustomModelsFile =
+    (pkgs.formats.json {}).generate "lemonade-user-models.json"
+    cfg.lemonade.customModels;
+
   # LEMONADE_DEFAULTS_PATH only seeds config.json on lemond's first run — after
   # that the persisted file wins for every key it holds, so module-declared
   # values rot. Re-apply ours each start. See noamsto/nix-amd-ai#67 and #68.
@@ -130,17 +134,37 @@
       # $XDG_CONFIG_HOME/lemonade with a $HOME/.config fallback. Reconciling the
       # old cache path writes a file nothing reads, and module keys go inert the
       # moment lemond persists anything of its own.
-      config="''${XDG_CONFIG_HOME:-''${HOME:-}/.config}/lemonade/config.json"
-      [ -f "$config" ] || exit 0
+      configDir="''${XDG_CONFIG_HOME:-''${HOME:-}/.config}/lemonade"
 
-      tmp="$config.nix-reconcile"
-      if jq -s '.[0] * .[1]' "$config" ${lemonadeDefaultsFile} >"$tmp"; then
-        # lemond may have tightened the mode; rename would silently widen it back.
-        chmod --reference="$config" "$tmp"
-        mv "$tmp" "$config"
+      config="$configDir/config.json"
+      if [ -f "$config" ]; then
+        tmp="$config.nix-reconcile"
+        if jq -s '.[0] * .[1]' "$config" ${lemonadeDefaultsFile} >"$tmp"; then
+          # lemond may have tightened the mode; rename would silently widen it back.
+          chmod --reference="$config" "$tmp"
+          mv "$tmp" "$config"
+        else
+          rm -f "$tmp"
+          echo "lemond: $config is unreadable, leaving it untouched" >&2
+        fi
+      fi
+    ''
+    + optionalString (cfg.lemonade.customModels != {}) ''
+
+      # Unlike config.json, this file is ours to create: lemond treats a missing
+      # user_models.json as an empty registry rather than seeding one, so nothing
+      # else makes it exist on a host that never opened the web UI.
+      models="$configDir/user_models.json"
+      mkdir -p "$configDir"
+      [ -f "$models" ] || echo '{}' >"$models"
+
+      tmp="$models.nix-reconcile"
+      if jq -s '.[0] * .[1]' "$models" ${lemonadeCustomModelsFile} >"$tmp"; then
+        chmod --reference="$models" "$tmp"
+        mv "$tmp" "$models"
       else
         rm -f "$tmp"
-        echo "lemond: $config is unreadable, leaving it untouched" >&2
+        echo "lemond: $models is unreadable, leaving it untouched" >&2
       fi
     '';
   };
@@ -419,6 +443,35 @@ in {
           machines reaching a non-loopback `lemonade.host`. `["*"]` allows
           any origin, which without an API key leaves the server open to any
           site the browser visits.
+        '';
+      };
+
+      customModels = mkOption {
+        type = (pkgs.formats.json {}).type;
+        default = {};
+        example = lib.literalExpression ''
+          {
+            "gpt-oss-120b-MXFP4-GGUF" = {
+              checkpoints.main = "ggml-org/gpt-oss-120b-GGUF:gpt-oss-120b-MXFP4.gguf";
+              recipe = "llamacpp";
+              recipe_options.ctx_size = 131072;
+              labels = ["chat" "reasoning" "tool-calling"];
+              size = 63.4;
+            };
+          }
+        '';
+        description = ''
+          Models registered by checkpoint rather than by registry name, merged
+          into `''${XDG_CONFIG_HOME:-~/.config}/lemonade/user_models.json`.
+          Reaches quantizations and repos the built-in registry doesn't carry.
+
+          Re-applied on every `lemond` start, so these stay declarative; models
+          registered through the web UI are left alone. An entry's
+          `recipe_options` block is that model's default — `recipe_options.json`
+          still layers the UI's per-model overrides on top of it.
+
+          A built-in of the same name is not replaced: lemond keys built-ins
+          bare and these as `user.<name>`, so both show in `lemonade list`.
         '';
       };
 

--- a/pkgs/lemonade/default.nix
+++ b/pkgs/lemonade/default.nix
@@ -129,14 +129,26 @@ in stdenv.mkDerivation {
     # losing GBs of partial download. Let the download finish in the
     # background; the next client poll will see it as installed. See
     # noamsto/nix-amd-ai#5.
+    #
+    # progress_cb fires per progress tick, not per disconnect, so logging on
+    # every failed write buries the journal once the socket is gone: 149998 of
+    # 150010 lines in a 3-minute window during one download, with journald
+    # dropping up to 529815 more per 30s. Latch it to one line per stream.
     substituteInPlace src/cpp/server/server.cpp \
+      --replace-fail \
+        'bool complete_sent = false;
+                DownloadProgressCallback progress_cb = [&sink, &complete_sent](const DownloadProgress& p) -> bool {' \
+        'bool complete_sent = false;
+                bool disconnect_logged = false;
+                DownloadProgressCallback progress_cb = [&sink, &complete_sent, &disconnect_logged](const DownloadProgress& p) -> bool {' \
       --replace-fail \
         'if (!sink.write(event.c_str(), event.size())) {
                         LOG(INFO, "Server") << "Client disconnected, cancelling download" << std::endl;
                         return false;
                     }
                     return true;' \
-        'if (!sink.write(event.c_str(), event.size())) {
+        'if (!sink.write(event.c_str(), event.size()) && !disconnect_logged) {
+                        disconnect_logged = true;
                         LOG(INFO, "Server") << "Client disconnected; download continues in background" << std::endl;
                     }
                     return true;'
@@ -154,6 +166,19 @@ in stdenv.mkDerivation {
         'bool will_install_therock(const std::string& os, const json& backend_versions) {' \
         'bool will_install_therock(const std::string& os, const json& backend_versions) {
     return false;  // nix-amd-ai#57: ship self-contained ROCm binaries, never fetch TheRock'
+
+    # ggml-org/gpt-oss-120b-GGUF gained EAGLE3 speculative-decoding drafts after
+    # upstream registered this model with a ":*" checkpoint glob, so the glob now
+    # resolves to eagle3-gpt-oss-120b-BF16.gguf (1.5 GB) instead of the 59 GiB
+    # weights. A draft head can't load standalone -- llama-server exits with
+    # "eagle3 requires ctx_other to be set" -- so `lemonade load` fails. Name the
+    # file, the form the other 227 entries use. The drafts stay unused: lemonade
+    # only emits --spec-type for dflash/mtp, and llama.cpp defaults it to none.
+    # See noamsto/nix-amd-ai#106; drop once upstream fixes the entry.
+    substituteInPlace src/cpp/resources/server_models.json \
+      --replace-fail \
+        '"checkpoint": "ggml-org/gpt-oss-120b-GGUF:*"' \
+        '"checkpoint": "ggml-org/gpt-oss-120b-GGUF:gpt-oss-120b-MXFP4.gguf"'
 
     # Pin backend_versions.json to whatever fastflowlm / llama-cpp /
     # whisper-cpp / sd-cpp builds we ship, so lemonade's "installed vs


### PR DESCRIPTION
Fixes #106.

## The bug

`lemonade load gpt-oss-120b-mxfp-GGUF` fails with `llama-server failed to start` on halo (gfx1151, lemonade 11.8.1).

Upstream registers the model with a wildcard checkpoint, `"ggml-org/gpt-oss-120b-GGUF:*"`. That was unambiguous when written; `ggml-org` has since added EAGLE3 speculative-decoding drafts to the repo, so the glob now resolves to `eagle3-gpt-oss-120b-BF16.gguf` (1.5 GB) instead of `gpt-oss-120b-MXFP4.gguf` (59 GiB). The live API reported `"size": 1.48` where the registry declares `63.4`. Running that file through our backend directly:

```
E llama_init_from_model: failed to initialize the context: eagle3 requires ctx_other to be set
E srv    load_model: failed to create_context with model .../eagle3-gpt-oss-120b-BF16.gguf
E srv  llama_server: exiting due to model loading error
```

A draft head cannot load standalone.

## Changes

**1. Name the checkpoint** (`pkgs/lemonade/default.nix`). One `substituteInPlace`, the form the other 227 registry entries use. This is the only `:*` entry in the registry, so a targeted patch is proportionate — a general `registryOverrides` resource overlay was considered and rejected as machinery for a one-instance problem.

Deliberately minimal. Lemonade does support a `draft` checkpoint (`llamacpp_server.cpp:314-378`, used by the Gemma-4 MTP entries), so those EAGLE3 files could become a real drafter — but `resolve_llamacpp_runtime_args` only emits `--spec-type` for `dflash`/`mtp` and llama.cpp defaults it to `none`, so a draft alone would not engage. That is an unmeasured perf change; per CLAUDE.md it needs numbers on this host first.

**2. `lemonade.customModels`** (`modules/amd-npu.nix`). Registers a model by checkpoint from the module instead of by hand-editing `user_models.json`, reconciled on every lemond start like `lemonade.settings`. Verified in `model_manager.cpp:1591-1609` that an inline `recipe_options` block is the registry-level default and `recipe_options.json` only layers UI overrides on top, so writing the one file is correct.

It cannot substitute for change 1: `build_cache` keys built-ins bare and user models as `user.<name>` into the same map (`model_manager.cpp:2804` vs `:2883`), so a user entry only ever adds a second row.

The reconcile now guards `config.json` separately — the old early `exit 0` when it was absent would have skipped this on any host that never opened the web UI, which is the case on halo.

**3. Latch the SSE disconnect log** (`pkgs/lemonade/default.nix`). The patch from #5 logs on every failed `sink.write`, but `progress_cb` fires per progress tick, not per disconnect. Measured during a background download: **149,998 of 150,010 journal lines in a 3-minute window**, with journald dropping up to 529,815 more per 30s. That is what destroyed the diagnostic evidence for the load failure above. Now one line per stream; #5 behaviour (download survives the disconnect) is unchanged.

## Verification

- `nix build .#lemonade` succeeds — which is the real test of the `--replace-fail` strings.
- Built output: `"gpt-oss-120b-mxfp-GGUF"` now reads `ggml-org/gpt-oss-120b-GGUF:gpt-oss-120b-MXFP4.gguf`, and zero `:*` entries remain.
- New `module-eval-lemonade-custom-models` check exercises the unit's own ExecStartPre: creates `user_models.json` when absent, restores a drifted declared entry, preserves a UI-registered model, and does not widen the file mode.
- `nix flake check` fully green.

Confirmed working on halo ahead of this patch via an equivalent hand-written `user_models.json` entry: the model loads the correct 59 GiB file and generates normally (`finish_reason: "stop"`, ~55 tok/s, harmony reasoning split into `reasoning_content`).

## Upstream

`main` still carries the bug, v11.9.0 (2026-09-02) included; no existing upstream issue found. Reporting it separately, along with the eagle3 `--spec-type` gap. Drop this patch once upstream fixes the entry.

Note also that **v11.9.0 is out** and this repo pins 11.8.1 — separate bump.

https://claude.ai/code/session_01XJxMMfWbyUbLPDEF37cP6S