### PR TITLE
fix(lemonade-app): add glib-networking so the webview can do HTTPS

### DIFF
--- a/pkgs/lemonade/tauri-app.nix
+++ b/pkgs/lemonade/tauri-app.nix
@@ -4,6 +4,7 @@
   pkg-config,
   wrapGAppsHook3,
   webkitgtk_4_1,
+  glib-networking,
   openssl,
   libayatana-appindicator,
   glib,
@@ -41,6 +42,10 @@ rustPlatform.buildRustPackage {
 
   buildInputs = [
     webkitgtk_4_1
+    # libsoup has no TLS of its own - it resolves a GTlsBackend through GIO at
+    # runtime, so without glib-networking every https:// fetch in the webview
+    # fails. wrapGAppsHook3 puts it on GIO_EXTRA_MODULES.
+    glib-networking
     openssl
     libayatana-appindicator
     glib


### PR DESCRIPTION
Fixes #18 — the Tauri app's "Marketplace unavailable / Load failed".

### Diagnosis

The issue listed three suspects; two are eliminated and the third is confirmed.

The marketplace fetch URL is `https://raw.githubusercontent.com/lemonade-sdk/marketplace/main/apps.json` (`src/app/src/renderer/utils/marketplace.ts:20`). From this host it returns **HTTP 200, 14 KB** — so the catalog has neither moved nor become unreachable, and this is not a lemond problem (the issue already established `/api/v1/health` and `/api/v1/models` were fine).

What's left is TLS inside the webview, and the closure says so plainly. libsoup implements no TLS of its own — it resolves a `GTlsBackend` through GIO at runtime, and `glib-networking` is the package that provides one. It was in neither `buildInputs` nor the closure:

```
$ nix-store -q --references <lemonade-app> | xargs -I{} ls {}/lib/gio/modules
libdconfsettings.so      # ← the only gio module in the whole closure
```

With no TLS backend, every `https://` request in the webview fails at connect and surfaces as WebKit's generic `Load failed`, while `http://localhost:13305` keeps working — precisely the split reported.

### Fix

Add `glib-networking` to `buildInputs`. `wrapGAppsHook3` already prefixes `GIO_EXTRA_MODULES` from there, so the dependency is the entire change:

```
libdconfsettings.so
libgiognutls.so          # ← the GTlsBackend
libgiognomeproxy.so
libgiolibproxy.so
```

The proxy resolvers come along for free, so the webview now honours a system proxy too — which was the issue's other suspected cause.

### Verification

Mechanical, and stated for what it is: before, the closure exposed only `libdconfsettings.so`; after, it exposes `libgiognutls.so`, and `glib-networking`'s module dir is on the wrapper's `GIO_EXTRA_MODULES`.

**The GUI confirmation is now done**, on `tp-g6` (x86_64-linux, graphical host). Both binaries were run under a nested headless `cage` compositor on that machine and screenshotted with `grim`, with `lemond` live on `:13305` and the app's `leftPanelView` preset to `marketplace`:

| Build | Marketplace tab |
|---|---|
| g6's current system app (no `glib-networking`) | `Marketplace unavailable: Load failed` — while the status bar reads `STATUS: CONNECTED` |
| this PR's `lemonade.tauri-app` | Catalog renders — AnythingLLM, Claude Code, Dify, Firefox Chatbot, GAIA… with remote favicons loaded over HTTPS |

The mechanism was isolated independently on the same host. Under GIO with only dconf on `GIO_EXTRA_MODULES` (what g6 ships today) versus dconf + `glib-networking` (this PR):

```
unpatched: backend = GDummyTlsBackend    supports_tls = False   TLS connect = FAIL - "TLS support is not available"
patched:   backend = GTlsBackendGnutls   supports_tls = True    TLS connect = OK
```

That is the whole defect: with no `GTlsBackend`, every `https://` request in the webview fails at connect, which WebKit surfaces as the generic `Load failed`. `http://localhost:13305` is unaffected, which is exactly the split #18 reported.

Worth noting the issue was filed against lemonade 10.6.0 and this is 11.8.1; the defect is in our packaging, not upstream's, which is why 14 releases never moved it.

https://claude.ai/code/session_017xaRyn9t3c5U4ZmQvvL7ri

https://claude.ai/code/session_01XJxMMfWbyUbLPDEF37cP6S
