### PR TITLE
fix(module): add the nix-ld libraries the openmoss TTS backends need

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -850,6 +850,64 @@
                 touch $out
               '';
 
+            # The openmoss TTS backends are runtime-downloaded foreign ELFs, so
+            # they resolve through nix-ld like koko does -- but they need more
+            # than koko: without libvulkan (and libomp/hipblas under enableROCm)
+            # moss-tts-server exits 127 and lemond reports "openmoss-server
+            # failed to start or become ready".
+            #
+            # The base set must survive too. programs.nix-ld.libraries is a
+            # listOf, so definitions concatenate; a definition that replaced the
+            # nixpkgs one instead of extending it would strip zlib/openssl/
+            # systemd and take koko down with it. Hence the zlib/openssl/systemd
+            # assertions below, which fail loudly on that regression.
+            module-eval-nix-ld-libraries = let
+              mkSys = extra:
+                (inputs.nixpkgs.lib.nixosSystem {
+                  inherit system;
+                  modules = [
+                    inputs.self.nixosModules.default
+                    {
+                      boot.loader.grub.enable = false;
+                      fileSystems."/" = {
+                        device = "/dev/sda1";
+                        fsType = "ext4";
+                      };
+                      hardware.amd-npu =
+                        {
+                          enable = true;
+                          enableLemonade = true;
+                          lemonade.user = "testuser";
+                        }
+                        // extra;
+                      users.users.testuser = {
+                        isNormalUser = true;
+                        extraGroups = ["video" "render"];
+                      };
+                    }
+                  ];
+                }).config.programs.nix-ld.libraries;
+              names = extra:
+                builtins.concatStringsSep " "
+                (map (p: p.pname or p.name) (mkSys extra));
+              plain = names {};
+              withRocm = names {enableROCm = true;};
+              lemonadeOff = names {enableLemonade = false;};
+            in
+              pkgs.runCommand "module-eval-nix-ld-libraries" {
+                inherit plain withRocm lemonadeOff;
+              } ''
+                for lib in vulkan-loader zlib openssl systemd; do
+                  echo "$plain" | grep -qw "$lib"                     || { echo "$lib missing from the lemonade nix-ld set"; exit 1; }
+                done
+                for lib in openmp clr rocblas hipblas; do
+                  echo "$withRocm" | grep -qw "$lib"                     || { echo "$lib missing under enableROCm"; exit 1; }
+                  ! echo "$plain" | grep -qw "$lib"                     || { echo "$lib pulled in without enableROCm"; exit 1; }
+                done
+                ! echo "$lemonadeOff" | grep -qw vulkan-loader                   || { echo "vulkan-loader added on a host with lemonade off"; exit 1; }
+                touch $out
+              '';
+
             # The lemond unit must keep its writable runtime dir + nix-ld loader
             # env, else omni backends (WhisperServer, koko TTS) fail to load. The
             # NIX_LD paths track the values nix-ld exports as session vars.

--- a/modules/amd-npu.nix
+++ b/modules/amd-npu.nix
@@ -751,6 +751,20 @@ in {
     # mkDefault so hosts managing nix-ld themselves can still opt out.
     programs.nix-ld.enable = mkIf cfg.enableLemonade (mkDefault true);
 
+    # The openmoss TTS backends need more than that base set. Both moss-tts-server
+    # builds exit 127 without these, and lemond reports "openmoss-server failed to
+    # start or become ready". Seen by running the binaries directly: the vulkan
+    # build stops at libvulkan.so.1, rocm-stable at libomp.so and then
+    # libhipblas.so.3. ldd is not a usable check here -- it does not go through
+    # nix-ld, so it prints "not found" for libraries that do resolve at runtime.
+    #
+    # libraries is a listOf, so definitions from every module concatenate: this
+    # adds to the nixpkgs base set rather than replacing it.
+    programs.nix-ld.libraries = mkIf cfg.enableLemonade (
+      [pkgs.vulkan-loader]
+      ++ optionals cfg.enableROCm (with pkgs.rocmPackages; [llvm.openmp clr rocblas hipblas])
+    );
+
     # Lemonade systemd service
     systemd.services.lemond = mkIf cfg.enableLemonade {
       description = "Lemonade AI Server";


### PR DESCRIPTION
`enableLemonade` enables nix-ld but adds no libraries, so the openmoss TTS
backends cannot start: `moss-tts-server` exits 127 and lemond reports
`openmoss-server failed to start or become ready`. The nixpkgs base set covers
koko, not openmoss.

Adds `vulkan-loader` under `enableLemonade`, and openmp/clr/rocblas/hipblas
under `enableROCm`. `programs.nix-ld.libraries` is a `listOf`, so this extends
the nixpkgs set rather than replacing it.

Also adds `checks.module-eval-nix-ld-libraries`, following the
`module-eval-gtt` pattern: vulkan-loader present, the ROCm libraries only under
`enableROCm`, nothing added when lemonade is off, and zlib/openssl/systemd
still there — that last one guards the replace-instead-of-extend regression.

### Testing

On a gfx1150 host, `x86_64-linux`:

- 16/16 non-VM checks build, including the new one
- `checks.lemond-vm` passes
- reverting only the module hunk makes the new check fail with
  `vulkan-loader missing from the lemonade nix-ld set`

The commit message carries the diagnosis and the hardware caveat: `rocm-stable`
still fails on gfx1150 for an unrelated reason (its prebuilt HIP bundle ships
gfx1030/gfx1100/gfx1151/gfx1201, no gfx1150), and I have no gfx1151 hardware to
confirm it works on a target its bundle does cover. The ROCm libraries are added
because the loader errors were observed, not because I got that backend
generating.
