### PR TITLE
fix(gaia): bump to 0.23.0 and drop the two console scripts upstream removed

### DIFF
--- a/pkgs/gaia/default.nix
+++ b/pkgs/gaia/default.nix
@@ -4,9 +4,14 @@
   writeShellScriptBin,
   uv,
 }: let
-  version = "0.17.6";
+  version = "0.23.0";
 
-  bins = ["gaia" "gaia-cli" "gaia-mcp" "gaia-emr" "gaia-code"];
+  # Upstream dropped the gaia-emr and gaia-code console scripts in 0.21.0
+  # (changelog: "drop stale gaia-emr smoke check", amd/gaia#1563). Verified
+  # against the published wheels' entry_points.txt: 0.20.0 still ships all
+  # five, 0.21.0 through 0.23.0 ship only these three. Keeping the other two
+  # would generate wrappers that fail at run time with "executable not found".
+  bins = ["gaia" "gaia-cli" "gaia-mcp"];
 
   # GAIA reads LEMONADE_BASE_URL from .env / environ; default it to lemond's
   # in-tree port (modules/amd-npu.nix lemonade.port = 13305) so users don't


### PR DESCRIPTION
`pkgs/gaia` pinned amd-gaia **0.17.6** (PyPI, 2026-05-07) and hard-coded five
console scripts. Two of those were removed upstream in 0.21.0, so a
version-only bump would have kept generating wrappers that fail at run time
with "executable not found".

```
0.17.6 - 0.20.0   gaia gaia-cli gaia-code gaia-emr gaia-mcp
0.21.0 - 0.23.0   gaia gaia-cli gaia-mcp
```

Beyond the version number: 0.23.0 is an explicit security release, and the gap
it closes lands squarely on this package — the confirmation gate that pauses an
agent before it sends mail, writes a file or runs a command used to work *only*
inside the Agent UI, not from a terminal, the local API or an MCP tool call.
CLI entry points are exactly what this package exposes. 0.18.0 fixes a
RAG-on-PDF timeout its own notes attribute by name to 0.17.6. 0.20.0 adds the
`--device npu` / `gaia init --profile npu` / FLM path.

### Testing

- `nix build .#gaia` → `gaia-0.23.0`, with exactly those three scripts.
- Each one runs: `gaia --help`, `gaia-cli --help` and `gaia-mcp --help` all
  exit 0 against a throwaway uv cache.
- `gaia-mcp` now advertises `--host` and `--auth-token`, matching the release
  notes.
- The `[ui]` extra and `Requires-Python` (`>=3.10`) are unchanged between the
  two versions, read from the wheel metadata.

The entry-point table above comes from the published wheels'
`entry_points.txt`, not from the changelog.

### User-visible

Two executables disappear from the package. They have been broken upstream
since June, so this is a fix — but anyone referencing them will now get an
evaluation error instead of a run-time one.

### Deliberately not included

Adding gaia to `scripts/check-updates.sh`. It is untracked today, which is how
it drifted 121 days and 10 releases. But a version-only `sed`, like the other
packages get in `bump-versions.sh`, would silently reintroduce this exact bug
the next time upstream changes its entry points — this PR is the evidence that
it happens. That needs a call on how much to automate, so I would rather raise
it as an issue than slip a design decision in here.
