### PR TITLE
feat(update): track gaia, including the console scripts it re-exports

### DIFF
--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -141,6 +141,14 @@ jobs:
             BODY+=$'\n'"**TODO:** drop \`llamaCppMtpOverride\` from \`flake.nix\` — nixpkgs llama-cpp has caught up to b${{ steps.check.outputs.mtp_required }} (what Lemonade pins)."$'\n'
           fi
 
+          if [ "${{ steps.check.outputs.gaia_needs_update }}" = "true" ]; then
+            BODY+=$'\n'"### ⚠️ gaia needs a hand-bump"$'\n'
+            BODY+="\`pkgs/gaia/default.nix\` names \`${{ steps.check.outputs.gaia_current }}\`; PyPI has \`${{ steps.check.outputs.gaia_latest }}\`."$'\n'
+            BODY+="Console scripts in the published wheel: \`${{ steps.check.outputs.gaia_scripts_latest }}\`"$'\n'
+            BODY+="Currently in \`bins\`: \`${{ steps.check.outputs.gaia_scripts_current }}\`"$'\n'
+            BODY+="Update \`version\`, and \`bins\` if those two lists differ. gaia is a uvx wrapper with no hash to prefetch and it builds green either way, so nothing else catches this."$'\n'
+          fi
+
           if [ "${{ steps.flake_check.outputs.status }}" = "fail" ]; then
             BODY+=$'\n'"### ⚠️ \`nix flake check\` failed"$'\n'
             BODY+=$'\n''```'$'\n'"$FLAKE_CHECK_LOG"$'\n''```'$'\n'
@@ -164,7 +172,8 @@ jobs:
           steps.pr.outputs.pr_url != '' &&
           steps.flake_check.outputs.status == 'pass' &&
           steps.build.outputs.failed == '' &&
-          steps.check.outputs.mtp_override_needs_update != 'true'
+          steps.check.outputs.mtp_override_needs_update != 'true' &&
+          steps.check.outputs.gaia_needs_update != 'true'
         env:
           GH_TOKEN: ${{ secrets.RELEASE_PAT }}
         run: gh pr merge --squash --delete-branch "${{ steps.pr.outputs.pr_url }}"

--- a/scripts/check-updates.sh
+++ b/scripts/check-updates.sh
@@ -93,6 +93,35 @@ if grep -q "llamaCppMtpOverride" flake.nix; then
   fi
 fi
 
+# gaia is a uvx wrapper: no hash to prefetch, and it builds green whatever
+# version it names, so nothing already here would ever notice it going stale.
+# The console scripts it re-exports are version-dependent — 0.21.0 dropped
+# gaia-emr and gaia-code — so report the script list alongside the version. A
+# version-only bump would ship wrappers for entry points that no longer exist.
+GAIA_CURRENT=$(sed -n 's/^  version = "\(.*\)";$/\1/p' pkgs/gaia/default.nix | head -1)
+GAIA_SCRIPTS_CURRENT=$(sed -n 's/^  bins = \[\(.*\)\];$/\1/p' pkgs/gaia/default.nix \
+  | tr -d '"' | tr ' ' '\n' | grep -v '^$' | sort | paste -sd' ' -)
+GAIA_LATEST=$(curl -fsSL https://pypi.org/pypi/amd-gaia/json | jq -r '.info.version')
+
+# Read the entry points from the published wheel rather than from the
+# changelog: the wheel is what uvx installs at run time.
+GAIA_WHEEL=$(mktemp -u /tmp/gaia-XXXXXX.whl)
+curl -fsSL "$(curl -fsSL "https://pypi.org/pypi/amd-gaia/${GAIA_LATEST}/json" \
+  | jq -r 'first(.urls[] | select(.filename | endswith(".whl")) | .url)')" -o "$GAIA_WHEEL"
+GAIA_SCRIPTS_LATEST=$(unzip -p "$GAIA_WHEEL" '*.dist-info/entry_points.txt' \
+  | awk '/^\[console_scripts\]/{f=1;next} /^\[/{f=0} f && /=/{sub(/=.*/,""); gsub(/[ \t]/,""); if ($0) print}' \
+  | sort | paste -sd' ' -)
+rm -f "$GAIA_WHEEL"
+
+GAIA_NEEDS_UPDATE=false
+if [ "$GAIA_LATEST" != "$GAIA_CURRENT" ] || [ "$GAIA_SCRIPTS_LATEST" != "$GAIA_SCRIPTS_CURRENT" ]; then
+  GAIA_NEEDS_UPDATE=true
+  NEEDS_UPDATE=true
+  echo "gaia: $GAIA_CURRENT -> $GAIA_LATEST"
+  [ "$GAIA_SCRIPTS_LATEST" != "$GAIA_SCRIPTS_CURRENT" ] \
+    && echo "  console scripts: [$GAIA_SCRIPTS_CURRENT] -> [$GAIA_SCRIPTS_LATEST]"
+fi
+
 if [ -n "${GITHUB_OUTPUT:-}" ]; then
   {
     echo "flm_latest=$FLM_LATEST"
@@ -110,6 +139,11 @@ if [ -n "${GITHUB_OUTPUT:-}" ]; then
     echo "mtp_override_needs_update=$MTP_OVERRIDE_NEEDS_UPDATE"
     echo "mtp_required=$MTP_REQUIRED"
     echo "mtp_current=$MTP_CURRENT"
+    echo "gaia_current=$GAIA_CURRENT"
+    echo "gaia_latest=$GAIA_LATEST"
+    echo "gaia_needs_update=$GAIA_NEEDS_UPDATE"
+    echo "gaia_scripts_current=$GAIA_SCRIPTS_CURRENT"
+    echo "gaia_scripts_latest=$GAIA_SCRIPTS_LATEST"
     # Multi-line outputs need the heredoc form (GitHub Actions docs).
     echo "nixpkgs_backend_diffs<<NIXPKGS_EOF"
     printf '%s' "$NIXPKGS_BACKEND_DIFFS"


### PR DESCRIPTION
Follow-up to #111, which bumped gaia from 0.17.6 to 0.23.0 after 121 days and
10 releases. This is the part that makes sure it gets noticed next time.

gaia is the one packaged dependency nothing watches: absent from
`check-updates.sh`, absent from `build.yml`, and — being a uvx wrapper — it
builds green whatever version it names. No existing gate can see it go stale.

### Why the version alone is not enough

The console scripts `amd-gaia` exports are version-dependent. 0.21.0 dropped
`gaia-emr` and `gaia-code`, so a version-only bump ships wrappers for entry
points that no longer exist, and the failure appears only when a user runs one.
That is exactly the bug #111 had to fix, so this reads the script list from the
published wheel's `entry_points.txt` — what uvx actually installs — and
compares it against `bins`.

### Design

This follows the MTP override precedent rather than inventing a mechanism:
detect, write a warning block into the PR body naming the exact edit, and stay
off the auto-merge path. The comment already in `update.yml` applies verbatim:

> MTP hand-bumps still build green with a stale override, so they stay for
> review.

**Deliberately not auto-bumped.** A `sed` on the version string, like the other
packages get in `bump-versions.sh`, would silently reintroduce #111's bug the
next time upstream changes its entry points. If you would rather automate it,
the honest version has to rewrite `bins` from the wheel too — happy to do that
instead, it just felt like your call rather than mine.

### Testing

The detection block was extracted from the committed file and run against two
real trees:

```
--- main (gaia 0.17.6, five scripts) ---
gaia: 0.17.6 -> 0.23.0
  console scripts: [gaia gaia-cli gaia-code gaia-emr gaia-mcp] -> [gaia gaia-cli gaia-mcp]
  -> gaia_needs_update=true  NEEDS_UPDATE=true

--- #111 branch (0.23.0, three scripts) ---
  -> gaia_needs_update=false  NEEDS_UPDATE=false
```

So it fires on today's `main` and goes quiet once #111 lands. Also: `bash -n`
clean, `shellcheck` clean (exit 0, no output), and `update.yml` still parses
with the extra auto-merge condition.

Not run end to end in CI — the script needs `gh` auth and does nixpkgs evals —
so the surrounding steps are unexercised by me. `unzip` and `curl` are both
present on `ubuntu-latest`; `jq` the script already uses.
