### PR TITLE
fix(ci): never cancel a main push, it owns the release tag

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,7 +7,10 @@ on:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  # Never cancel a push to main: the release job below tags only on push, so a
+  # run cancelled by the next merge drops that release for good and nothing
+  # retries it. Superseded PR runs are still worth cancelling.
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
   build:


### PR DESCRIPTION
The `concurrency` group is shared by every push to `main` with `cancel-in-progress: true`, so merging several PRs in quick succession kills the earlier runs. The `release` job only tags on push, so a cancelled run drops that release permanently — nothing retries it.

This is not hypothetical. #110, #111 and #112 merged within three minutes today:

| Run | Commit | Outcome | Should have released? |
|---|---|---|---|
| #111 gaia 0.23.0 | `3cc12c0` | **cancelled** | yes — touches `pkgs/` |
| #110 nix-ld libs | `731f213` | **cancelled** | yes — touches `flake.nix` |
| #112 update tracking | `bbecd61` | success | no — only `.github/` + `scripts/` |

The only run that survived is the one whose release job correctly declines to tag, so no release was cut at all. `v2026.09.05` was created by hand to recover the two lost ones.

## The fix

```yaml
cancel-in-progress: ${{ github.event_name == 'pull_request' }}
```

Cancellation is still right for pull requests — superseding a force-pushed run is the whole point — and now never applies to `main`, where the run carries the release.

## Testing

`yq` parses the workflow and reads back the expression intact. The behaviour itself only exercises on a real double-merge to `main`, which this PR cannot rehearse; the expression form is the documented GitHub idiom for exactly this case.

https://claude.ai/code/session_01GPwipeq938W3UXUBHYVuwe