### PR TITLE
fix(vllm-rocm): supply liblzma, torch cannot import without it

### DIFF
--- a/pkgs/vllm-rocm/default.nix
+++ b/pkgs/vllm-rocm/default.nix
@@ -5,13 +5,18 @@
 # resulting `vllm-server` via the `vllm.rocm_bin` config override wired in the
 # NixOS module. See noamsto/nix-amd-ai#63.
 #
-# NOTE: deliberately NOT autoPatchelf'd. The bundle is self-contained — it ships
-# its own `rocm_sysdeps` (numa/drm/elf/lzma) and resolves its .so via internal
-# $ORIGIN runpaths. autoPatchelfHook rewrites those runpaths and injects nixpkgs
-# libs (gcc-15 libstdc++/libatomic) that mismatch the Ubuntu-built torch, which
-# segfaults on `import torch`. Instead we only repoint the ELF interpreter to the
-# nix loader and supply the two genuinely-missing system libs (libstdc++, libz)
-# via the launcher's LD_LIBRARY_PATH.
+# NOTE: deliberately NOT autoPatchelf'd. The bundle is mostly self-contained — it
+# ships its own `rocm_sysdeps` and resolves its .so via internal $ORIGIN runpaths.
+# autoPatchelfHook rewrites those runpaths and injects nixpkgs libs (gcc-15
+# libstdc++/libatomic) that mismatch the Ubuntu-built torch, which segfaults on
+# `import torch`. Instead we only repoint the ELF interpreter to the nix loader
+# and supply the genuinely-missing system libs via the launcher's
+# LD_LIBRARY_PATH.
+#
+# The `rocm_sysdeps` set does not count as shipping those libs: every member is
+# renamed (`librocm_sysdeps_liblzma.so.5`), so a plain `liblzma.so.5` DT_NEEDED
+# does not resolve against it. torch/lib/libaotriton_v2.so has exactly that,
+# which is why xz is here.
 {
   lib,
   stdenv,
@@ -21,6 +26,7 @@
   bash,
   coreutils,
   zlib,
+  xz,
   gpuTarget ? "gfx1150",
 }: let
   sources = import ./sources.nix;
@@ -29,7 +35,7 @@
     or (throw "vllm-rocm: no prebuilt for gpuTarget '${gpuTarget}' (have: ${lib.concatStringsSep ", " (lib.attrNames sources)})");
   parts = map (p: fetchurl {inherit (p) url hash;}) src.parts;
   # Ubuntu-built torch/ROCm want these from the system; the bundle omits them.
-  runtimeLibs = lib.makeLibraryPath [stdenv.cc.cc.lib zlib];
+  runtimeLibs = lib.makeLibraryPath [stdenv.cc.cc.lib zlib xz.out];
 in
   stdenv.mkDerivation {
     pname = "vllm-rocm";


### PR DESCRIPTION
First run of this package on real Halo hardware (Ryzen AI MAX+ 395, gfx1151). It does not start.

```
File "torch/__init__.py", line 444, in <module>
  from torch._C import *
ImportError: liblzma.so.5: cannot open shared object file: No such file or directory
```

`torch/lib/libaotriton_v2.so` carries a plain `liblzma.so.5` DT_NEEDED. The bundle does ship an lzma — but every `rocm_sysdeps` member is renamed:

```
_rocm_sdk_core/lib/rocm_sysdeps/lib/librocm_sysdeps_liblzma.so.5
```

so it never satisfies that lookup. `runtimeLibs` offered only `libstdc++` and `libz`, so nothing else covered it. The header comment claimed the bundle ships its own lzma, which is how the gap survived — corrected to say why the namespaced copy does not count.

## Why CI never caught it

`module-eval-vllm` deliberately avoids realizing the 7.6 GB bundle, and no CI host has a gfx1151 GPU. `sources.nix` was explicit that packaging was verified but **no gfx1151 kernel had ever executed**. This is what was hiding behind that caveat.

## Testing — on gfx1151

With the fix, and no `LD_LIBRARY_PATH` help:

- `vllm-server --help` imports torch + vLLM cleanly.
- torch reports `gfx1151`, `torch 2.12.0+rocm7.15.0a20260724`, HIP `7.15.0`; an fp16 2048×2048 matmul returns mean |C| ≈ 36.13, matching the analytic √2048·√(2/π) ≈ 36.13 — so the kernel computed, it did not merely not crash.
- End-to-end serve, `facebook/opt-125m`, `--enforce-eager`:

```
Available KV cache memory: 35.8 GiB
GPU KV cache size: 1,042,848 tokens
Application startup complete.

$ curl /v1/completions -d {"prompt":"The capital of France is","max_tokens":16}
" the capital of the French Republic.\n\nThe capital of France is the capital"
```

That is the first gfx1151 kernel this package has ever run, so the `sources.nix` caveat can be rewritten — I have left that to a follow-up rather than bundle it here.

Two things I did **not** do: the 9B run the bring-up checklist asks for as the "not only toy-sized" confirmation (~18 GB pull), and any check on whether gfx1150 has the same latent gap. The wrapper is target-independent and `libaotriton_v2.so` ships in both bundles, so gfx1150 is very likely affected too — but I have not verified it and did not want to assert it.

https://claude.ai/code/session_01GPwipeq938W3UXUBHYVuwe