### PR TITLE
fix(meta): correct two licenses and the transferred FastFlowLM repo path

### DIFF
--- a/pkgs/fastflowlm/default.nix
+++ b/pkgs/fastflowlm/default.nix
@@ -97,8 +97,8 @@ stdenv.mkDerivation (finalAttrs: {
 
   meta = {
     description = "NPU-optimized LLM runtime for AMD Ryzen AI";
-    homepage = "https://github.com/FastFlowLM/FastFlowLM";
-    license = lib.licenses.asl20;
+    homepage = "https://github.com/ROCm/FastFlowLM";
+    license = lib.licenses.mit;
     platforms = ["x86_64-linux"];
     mainProgram = "flm";
   };

--- a/pkgs/lemonade/tauri-app.nix
+++ b/pkgs/lemonade/tauri-app.nix
@@ -84,7 +84,7 @@ rustPlatform.buildRustPackage {
   meta = {
     description = "Lemonade desktop app (Tauri shell around the React UI)";
     homepage = "https://github.com/lemonade-sdk/lemonade";
-    license = lib.licenses.mit;
+    license = lib.licenses.asl20;
     platforms = ["x86_64-linux"];
     mainProgram = "lemonade-app";
   };

--- a/scripts/check-updates.sh
+++ b/scripts/check-updates.sh
@@ -3,7 +3,7 @@
 # Outputs GitHub Actions variables via GITHUB_OUTPUT.
 set -euo pipefail
 
-FLM_LATEST=$(gh api repos/FastFlowLM/FastFlowLM/releases/latest --jq '.tag_name' | sed 's/^v//')
+FLM_LATEST=$(gh api repos/ROCm/FastFlowLM/releases/latest --jq '.tag_name' | sed 's/^v//')
 LEM_LATEST=$(gh api repos/lemonade-sdk/lemonade/releases/latest --jq '.tag_name' | sed 's/^v//')
 XDNA_LATEST=$(gh api "repos/amd/xdna-driver/commits?sha=1.7&per_page=1" --jq '.[0].sha')
 # vLLM-ROCm cuts one release per gfx target, so `releases/latest` returns


### PR DESCRIPTION
I checked every `meta.license` in `pkgs/` against the upstream `LICENSE` files. Two don't match, and one repo has moved.

### `fastflowlm`: `asl20` → `mit`

`ROCm/FastFlowLM` ships exactly one license file, `LICENSE_RUNTIME.txt`, present at `v1.0.4` — the tag this package builds:

```
MIT License

Copyright (c) 2026 Advanced Micro Devices, Inc.
```

One caveat I can't settle from the outside: the name `LICENSE_RUNTIME.txt` hints the prebuilt NPU artifacts might carry separate terms. I found no second license file in the tree, so the only thing I can state positively is that Apache-2.0 isn't it.

### `lemonade-app`: `mit` → `asl20`

This one is an internal inconsistency rather than a lookup error. `tauri-app.nix` receives the same `src` as its four siblings — `default.nix`, `darwin.nix`, `web-app.nix`, `tauri-frontend.nix` — and all four declare `asl20`. `src/app/src-tauri` has no license file of its own at `v11.9.0`, so it inherits the repo root `LICENSE`, which is Apache-2.0.

### `FastFlowLM/FastFlowLM` → `ROCm/FastFlowLM`

The repo was transferred: `gh api repos/FastFlowLM/FastFlowLM` resolves to `full_name: ROCm/FastFlowLM`. The `homepage` and the release lookup in `check-updates.sh:6` both still name the old path. They work today through GitHub's redirect, but that redirect ends the moment someone claims the vacated org name — and `check-updates.sh` is precisely the thing that would go quiet rather than fail loudly.

Happy to split the script line out into its own PR if you'd rather keep `meta` changes separate.

---

Unrelated to the fix, but worth saying since I had to read a fair bit of `pkgs/` to be sure of the above: this is a notably well-kept tree. Every fetcher is fixed-output with a full SHA, there's no `fetchgit` on a branch anywhere, the comments explain the *why* and cite upstream issue numbers, and there's a real NixOS VM test rather than eval-only checks. That's well above what this niche usually looks like.

It's also why these two felt worth a PR at all. In a repo where the license fields were roughly right and nobody looked twice, two wrong ones wouldn't stand out. Here they do.
