### PR TITLE
fix(update): pass step outputs through env: instead of into run: bodies

### DIFF
--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -43,12 +43,20 @@ jobs:
         if: steps.check.outputs.needs_update == 'true'
         env:
           GH_TOKEN: ${{ github.token }}
+          FLM_LATEST: ${{ steps.check.outputs.flm_latest }}
+          FLM_CURRENT: ${{ steps.check.outputs.flm_current }}
+          LEM_LATEST: ${{ steps.check.outputs.lem_latest }}
+          LEM_CURRENT: ${{ steps.check.outputs.lem_current }}
+          XDNA_LATEST: ${{ steps.check.outputs.xdna_latest }}
+          XDNA_CURRENT: ${{ steps.check.outputs.xdna_current }}
+          VLLM_LATEST: ${{ steps.check.outputs.vllm_latest }}
+          VLLM_CURRENT: ${{ steps.check.outputs.vllm_current }}
         run: |
           ./scripts/bump-versions.sh \
-            "${{ steps.check.outputs.flm_latest }}" "${{ steps.check.outputs.flm_current }}" \
-            "${{ steps.check.outputs.lem_latest }}" "${{ steps.check.outputs.lem_current }}" \
-            "${{ steps.check.outputs.xdna_latest }}" "${{ steps.check.outputs.xdna_current }}" \
-            "${{ steps.check.outputs.vllm_latest }}" "${{ steps.check.outputs.vllm_current }}"
+            "$FLM_LATEST" "$FLM_CURRENT" \
+            "$LEM_LATEST" "$LEM_CURRENT" \
+            "$XDNA_LATEST" "$XDNA_CURRENT" \
+            "$VLLM_LATEST" "$VLLM_CURRENT"
 
       # vllm-rocm builds unpack ~7.6 GB; the runner's ~14 GB default isn't enough.
       # Reclaim the preinstalled Android/.NET/GHC toolchains (~25 GB) so the
@@ -66,23 +74,30 @@ jobs:
             echo "status=pass" >> "$GITHUB_OUTPUT"
           else
             echo "status=fail" >> "$GITHUB_OUTPUT"
+            # Random delimiter: this is nix output, so a line reading
+            # CHECK_EOF would close the block early and let whatever follows
+            # write arbitrary step outputs -- including the `status` that
+            # gates auto-merge below.
+            delim="EOF_$(openssl rand -hex 16)"
             {
-              echo "log<<CHECK_EOF"
+              echo "log<<$delim"
               tail -40 /tmp/flake-check.log
-              echo "CHECK_EOF"
+              echo "$delim"
             } >> "$GITHUB_OUTPUT"
           fi
 
       - name: Build updated packages
         if: steps.check.outputs.needs_update == 'true'
         id: build
+        env:
+          VLLM_NEEDS_UPDATE: ${{ steps.check.outputs.vllm_needs_update }}
         run: |
           FAILED=""
           PKGS="xrt xrt-plugin-amdxdna fastflowlm lemonade"
           # Validate the vllm-rocm bump only when it moved — building it (and
           # re-fetching 2.25 GB) every run when unchanged is pure waste since it
           # isn't in the cache. A build failure here blocks the auto-merge below.
-          if [ "${{ steps.check.outputs.vllm_needs_update }}" = "true" ]; then
+          if [ "$VLLM_NEEDS_UPDATE" = "true" ]; then
             PKGS="$PKGS vllm-rocm"
           fi
           for pkg in $PKGS; do
@@ -90,10 +105,11 @@ jobs:
               FAILED+="- ${pkg}"$'\n'
             fi
           done
+          delim="EOF_$(openssl rand -hex 16)"
           {
-            echo "failed<<BUILD_EOF"
+            echo "failed<<$delim"
             printf '%s' "$FAILED"
-            echo "BUILD_EOF"
+            echo "$delim"
           } >> "$GITHUB_OUTPUT"
 
       - name: Create PR
@@ -102,7 +118,27 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
           FLAKE_CHECK_LOG: ${{ steps.flake_check.outputs.log }}
+          FLAKE_CHECK_STATUS: ${{ steps.flake_check.outputs.status }}
           BUILD_FAILED: ${{ steps.build.outputs.failed }}
+          FLM_LATEST: ${{ steps.check.outputs.flm_latest }}
+          FLM_CURRENT: ${{ steps.check.outputs.flm_current }}
+          LEM_LATEST: ${{ steps.check.outputs.lem_latest }}
+          LEM_CURRENT: ${{ steps.check.outputs.lem_current }}
+          XDNA_LATEST: ${{ steps.check.outputs.xdna_latest }}
+          XDNA_CURRENT: ${{ steps.check.outputs.xdna_current }}
+          VLLM_LATEST: ${{ steps.check.outputs.vllm_latest }}
+          VLLM_CURRENT: ${{ steps.check.outputs.vllm_current }}
+          VLLM_NEEDS_UPDATE: ${{ steps.check.outputs.vllm_needs_update }}
+          NIXPKGS_DIFFS: ${{ steps.check.outputs.nixpkgs_backend_diffs }}
+          MTP_OVERRIDE_NEEDS_UPDATE: ${{ steps.check.outputs.mtp_override_needs_update }}
+          MTP_CLEANUP: ${{ steps.check.outputs.mtp_cleanup }}
+          MTP_REQUIRED: ${{ steps.check.outputs.mtp_required }}
+          MTP_CURRENT: ${{ steps.check.outputs.mtp_current }}
+          GAIA_NEEDS_UPDATE: ${{ steps.check.outputs.gaia_needs_update }}
+          GAIA_CURRENT: ${{ steps.check.outputs.gaia_current }}
+          GAIA_LATEST: ${{ steps.check.outputs.gaia_latest }}
+          GAIA_SCRIPTS_LATEST: ${{ steps.check.outputs.gaia_scripts_latest }}
+          GAIA_SCRIPTS_CURRENT: ${{ steps.check.outputs.gaia_scripts_current }}
         run: |
           git diff --quiet && echo "No changes" && exit 0
 
@@ -115,41 +151,40 @@ jobs:
           git push origin "$BRANCH"
 
           BODY="## Upstream updates detected"$'\n\n'
-          [ "${{ steps.check.outputs.flm_latest }}" != "${{ steps.check.outputs.flm_current }}" ] && \
-            BODY+="- FastFlowLM: ${{ steps.check.outputs.flm_current }} -> ${{ steps.check.outputs.flm_latest }}"$'\n'
-          [ "${{ steps.check.outputs.lem_latest }}" != "${{ steps.check.outputs.lem_current }}" ] && \
-            BODY+="- Lemonade: ${{ steps.check.outputs.lem_current }} -> ${{ steps.check.outputs.lem_latest }}"$'\n'
-          [ "${{ steps.check.outputs.xdna_latest }}" != "${{ steps.check.outputs.xdna_current }}" ] && \
-            BODY+="- xdna-driver: ${{ steps.check.outputs.xdna_current }} -> ${{ steps.check.outputs.xdna_latest }}"$'\n'
-          if [ "${{ steps.check.outputs.vllm_needs_update }}" = "true" ]; then
-            BODY+="- vLLM-ROCm: \`${{ steps.check.outputs.vllm_current }}\` -> \`${{ steps.check.outputs.vllm_latest }}\` (built to validate; not GPU-tested)"$'\n'
+          [ "$FLM_LATEST" != "$FLM_CURRENT" ] && \
+            BODY+="- FastFlowLM: $FLM_CURRENT -> $FLM_LATEST"$'\n'
+          [ "$LEM_LATEST" != "$LEM_CURRENT" ] && \
+            BODY+="- Lemonade: $LEM_CURRENT -> $LEM_LATEST"$'\n'
+          [ "$XDNA_LATEST" != "$XDNA_CURRENT" ] && \
+            BODY+="- xdna-driver: $XDNA_CURRENT -> $XDNA_LATEST"$'\n'
+          if [ "$VLLM_NEEDS_UPDATE" = "true" ]; then
+            BODY+="- vLLM-ROCm: \`$VLLM_CURRENT\` -> \`$VLLM_LATEST\` (built to validate; not GPU-tested)"$'\n'
           fi
 
-          NIXPKGS_DIFFS='${{ steps.check.outputs.nixpkgs_backend_diffs }}'
           if [ -n "$NIXPKGS_DIFFS" ]; then
             BODY+=$'\n'"### nixpkgs backend versions"$'\n'
             BODY+="$NIXPKGS_DIFFS"
           fi
 
-          if [ "${{ steps.check.outputs.mtp_override_needs_update }}" = "true" ]; then
+          if [ "$MTP_OVERRIDE_NEEDS_UPDATE" = "true" ]; then
             BODY+=$'\n'"### ⚠️ MTP override needs hand-bump"$'\n'
-            BODY+="Lemonade v${{ steps.check.outputs.lem_latest }} pins \`llamacpp.vulkan = b${{ steps.check.outputs.mtp_required }}\`, but \`llamaCppMtpOverride\` in \`flake.nix\` is at \`b${{ steps.check.outputs.mtp_current }}\`."$'\n'
-            BODY+="Update \`version\`, \`rev\` (commit for tag \`b${{ steps.check.outputs.mtp_required }}\` in \`ggml-org/llama.cpp\`), and both hashes in the \`llamaCppMtpSrc\` / \`llamaCppMtpOverride\` blocks."$'\n'
+            BODY+="Lemonade v$LEM_LATEST pins \`llamacpp.vulkan = b$MTP_REQUIRED\`, but \`llamaCppMtpOverride\` in \`flake.nix\` is at \`b$MTP_CURRENT\`."$'\n'
+            BODY+="Update \`version\`, \`rev\` (commit for tag \`b$MTP_REQUIRED\` in \`ggml-org/llama.cpp\`), and both hashes in the \`llamaCppMtpSrc\` / \`llamaCppMtpOverride\` blocks."$'\n'
           fi
 
-          if [ "${{ steps.check.outputs.mtp_cleanup }}" = "true" ]; then
-            BODY+=$'\n'"**TODO:** drop \`llamaCppMtpOverride\` from \`flake.nix\` — nixpkgs llama-cpp has caught up to b${{ steps.check.outputs.mtp_required }} (what Lemonade pins)."$'\n'
+          if [ "$MTP_CLEANUP" = "true" ]; then
+            BODY+=$'\n'"**TODO:** drop \`llamaCppMtpOverride\` from \`flake.nix\` — nixpkgs llama-cpp has caught up to b$MTP_REQUIRED (what Lemonade pins)."$'\n'
           fi
 
-          if [ "${{ steps.check.outputs.gaia_needs_update }}" = "true" ]; then
+          if [ "$GAIA_NEEDS_UPDATE" = "true" ]; then
             BODY+=$'\n'"### ⚠️ gaia needs a hand-bump"$'\n'
-            BODY+="\`pkgs/gaia/default.nix\` names \`${{ steps.check.outputs.gaia_current }}\`; PyPI has \`${{ steps.check.outputs.gaia_latest }}\`."$'\n'
-            BODY+="Console scripts in the published wheel: \`${{ steps.check.outputs.gaia_scripts_latest }}\`"$'\n'
-            BODY+="Currently in \`bins\`: \`${{ steps.check.outputs.gaia_scripts_current }}\`"$'\n'
+            BODY+="\`pkgs/gaia/default.nix\` names \`$GAIA_CURRENT\`; PyPI has \`$GAIA_LATEST\`."$'\n'
+            BODY+="Console scripts in the published wheel: \`$GAIA_SCRIPTS_LATEST\`"$'\n'
+            BODY+="Currently in \`bins\`: \`$GAIA_SCRIPTS_CURRENT\`"$'\n'
             BODY+="Update \`version\`, and \`bins\` if those two lists differ. gaia is a uvx wrapper with no hash to prefetch and it builds green either way, so nothing else catches this."$'\n'
           fi
 
-          if [ "${{ steps.flake_check.outputs.status }}" = "fail" ]; then
+          if [ "$FLAKE_CHECK_STATUS" = "fail" ]; then
             BODY+=$'\n'"### ⚠️ \`nix flake check\` failed"$'\n'
             BODY+=$'\n''```'$'\n'"$FLAKE_CHECK_LOG"$'\n''```'$'\n'
           fi
@@ -176,4 +211,5 @@ jobs:
           steps.check.outputs.gaia_needs_update != 'true'
         env:
           GH_TOKEN: ${{ secrets.RELEASE_PAT }}
-        run: gh pr merge --squash --delete-branch "${{ steps.pr.outputs.pr_url }}"
+          PR_URL: ${{ steps.pr.outputs.pr_url }}
+        run: gh pr merge --squash --delete-branch "$PR_URL"

--- a/scripts/check-updates.sh
+++ b/scripts/check-updates.sh
@@ -122,6 +122,33 @@ if [ "$GAIA_LATEST" != "$GAIA_CURRENT" ] || [ "$GAIA_SCRIPTS_LATEST" != "$GAIA_S
     && echo "  console scripts: [$GAIA_SCRIPTS_CURRENT] -> [$GAIA_SCRIPTS_LATEST]"
 fi
 
+# Everything above came from an upstream release tag or from names read out of
+# a published wheel, and it flows on into sed expressions in bump-versions.sh
+# and into the PR body. Git tag names and wheel entry-point names are far more
+# permissive than either consumer assumes: a / or & silently corrupts the sed,
+# and $(...) or a backtick reaches a shell. Refuse anything outside a
+# conservative charset rather than pass it along.
+reject_odd() {
+  [[ "$2" =~ ^[A-Za-z0-9._+-]+$ ]] || {
+    echo "ERROR: unexpected characters in $1: $2" >&2
+    exit 1
+  }
+}
+reject_odd_list() {
+  [[ "$2" =~ ^([A-Za-z0-9._+-]+( [A-Za-z0-9._+-]+)*)?$ ]] || {
+    echo "ERROR: unexpected characters in $1: $2" >&2
+    exit 1
+  }
+}
+
+reject_odd FLM_LATEST "$FLM_LATEST"
+reject_odd LEM_LATEST "$LEM_LATEST"
+reject_odd XDNA_LATEST "$XDNA_LATEST"
+reject_odd VLLM_LATEST "$VLLM_LATEST"
+reject_odd GAIA_LATEST "$GAIA_LATEST"
+reject_odd_list GAIA_SCRIPTS_LATEST "$GAIA_SCRIPTS_LATEST"
+[ -z "$MTP_REQUIRED" ] || reject_odd MTP_REQUIRED "$MTP_REQUIRED"
+
 if [ -n "${GITHUB_OUTPUT:-}" ]; then
   {
     echo "flm_latest=$FLM_LATEST"
@@ -144,9 +171,13 @@ if [ -n "${GITHUB_OUTPUT:-}" ]; then
     echo "gaia_needs_update=$GAIA_NEEDS_UPDATE"
     echo "gaia_scripts_current=$GAIA_SCRIPTS_CURRENT"
     echo "gaia_scripts_latest=$GAIA_SCRIPTS_LATEST"
-    # Multi-line outputs need the heredoc form (GitHub Actions docs).
-    echo "nixpkgs_backend_diffs<<NIXPKGS_EOF"
+    # Multi-line output needs the heredoc form (GitHub Actions docs). Random
+    # delimiter: the content is nix-eval output, and a line equal to a fixed
+    # delimiter would close the block early and let the rest write arbitrary
+    # step outputs -- same reason the flake-check log uses one in update.yml.
+    nixpkgs_delim="NIXPKGS_EOF_$(openssl rand -hex 16)"
+    echo "nixpkgs_backend_diffs<<$nixpkgs_delim"
     printf '%s' "$NIXPKGS_BACKEND_DIFFS"
-    echo "NIXPKGS_EOF"
+    echo "$nixpkgs_delim"
   } >> "$GITHUB_OUTPUT"
 fi


### PR DESCRIPTION
### Scope first, so this doesn't read as more than it is

`update.yml` runs only on `schedule` / `workflow_dispatch`. There's no `pull_request_target` or `workflow_run` anywhere in the repo, so **none of this is remotely exploitable** — reaching it takes a compromised upstream publisher (one of the three release repos, or the `amd-gaia` PyPI account). This is supply-chain hardening, not an emergency, and I've kept the diff to plumbing only.

Full disclosure: three of the interpolations this fixes are mine, from #112. I added them matching the surrounding lines instead of the safer pattern two steps up in the same file, and I should have caught the difference then. This cleans up the whole class rather than just my three.

### The problem

`${{ }}` is a textual substitution done before bash parses the script, so a value that lands in a `run:` body becomes shell source, not data. Double quotes don't help — `$( )` still expands inside them. The values here come from upstream tags and from console-script names read out of a published wheel, and both are more permissive than the consumers assume:

- `git check-ref-format` leaves `$`, `` ` ``, `(`, `)`, `;`, `&`, `"` all legal in a tag name — I confirmed `v";id>x;#` is accepted.
- Wheel entry-point names are free text per the packaging spec, and a wheel is just a zip whose `entry_points.txt` can be written by hand. The awk filter in `check-updates.sh` cuts at the first `=` and deletes every space and tab, so a payload only has to be space-free: `gaia-cli$(id)` comes through intact.

Verified on Linux under `bash -e` (the runner's default shell): with the current line a wheel-name payload executes and the PR body silently drops it; with the fix it stays a literal string.

```
OLD  ->  Console scripts in the published wheel: `gaia gaia-cliuid=1000(...) ...`   <- id ran
NEW  ->  Console scripts in the published wheel: `gaia gaia-cli$(id)`                <- literal
```

What an attacker would get: code execution in a job holding `contents: write`, the cachix token, and — on the tag vectors, **not** the gaia one, since `gaia_needs_update` gates the auto-merge — `RELEASE_PAT`.

### The fix

1. **Every `${{ }}` that was in a `run:` now goes through `env:`**, and the shell reads `"$VAR"`. This is the pattern the repo already uses for `FLAKE_CHECK_LOG` / `BUILD_FAILED` in the same step, and `BEFORE` / `SHA` in `build.yml`. After this, no `run:` body in any workflow contains an interpolation. `if:` and `with:` are left as-is; the `env:` values reach the shell, but as environment variables it never parses as source text.

2. **Random heredoc delimiters** for the three `GITHUB_OUTPUT` here-docs whose content isn't fully in-repo (the flake-check log, the nixpkgs diffs, the build-failure list). A fixed delimiter appearing on a content line closes the block early and lets the rest write arbitrary step outputs — including the `status` / `gaia_needs_update` / `mtp_override_needs_update` that gate auto-merge.

3. **A charset filter in `check-updates.sh`** before anything is written to `GITHUB_OUTPUT`. `env:` covers the PR body but not `bump-versions.sh`, which splices these same values into `sed` expressions — a `/` or `&` corrupts the substitution, and GNU sed has flags (`e`) that make a crafted value worth refusing outright rather than reasoning about case by case. It rejects anything outside `[A-Za-z0-9._+-]` (plus single spaces for the script list).

### Testing

- PR body **byte-for-byte identical** before/after across 12 scenarios, including replays of the inputs behind #109 and #92 — this is meant to change zero behavior on the happy path.
- Filter checked against every real value: 40+ FastFlowLM tags, 60+ lemonade, 47 vllm-rocm (including the `+`/dot dev tag), 30 `amd-gaia` releases, and an empty script list all pass; the normal empty `MTP_REQUIRED` is guarded. The trade-off: a benign-but-unusual upstream tag outside the charset now fails the weekly job rather than flowing on.
- `bash -n` + `shellcheck` clean; YAML re-parses; `openssl` is present on `ubuntu-latest`.

### Out of scope, but worth flagging

Two actions in these same jobs are pinned to `@main` (`DeterminateSystems/nix-installer-action`, `jlumbroso/free-disk-space`) — a strictly larger vector than the one fixed here, since they run arbitrary third-party code in the privileged job. Pinning them to SHAs is a separate, larger change; happy to send it next if you're interested. I didn't want to bundle it in.
