### PR TITLE
ci: pin all actions to full-length commit SHAs

### DIFF
--- a/.github/workflows/auto-assign.yml
+++ b/.github/workflows/auto-assign.yml
@@ -10,7 +10,7 @@ jobs:
     permissions:
       issues: write
     steps:
-      - uses: actions/github-script@v9
+      - uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
         with:
           script: |
             await github.rest.issues.addAssignees({

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,9 +13,9 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
-      - uses: DeterminateSystems/nix-installer-action@main
-      - uses: cachix/cachix-action@v17
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+      - uses: DeterminateSystems/nix-installer-action@ef8a148080ab6020fd15196c2084a2eea5ff2d25 # v22
+      - uses: cachix/cachix-action@38b082610b782e7e93e209c35fd730d399dee866 # v17
         with:
           name: nix-amd-ai
           authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
@@ -48,9 +48,9 @@ jobs:
   build-darwin:
     runs-on: macos-15
     steps:
-      - uses: actions/checkout@v7
-      - uses: DeterminateSystems/nix-installer-action@main
-      - uses: cachix/cachix-action@v17
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+      - uses: DeterminateSystems/nix-installer-action@ef8a148080ab6020fd15196c2084a2eea5ff2d25 # v22
+      - uses: cachix/cachix-action@38b082610b782e7e93e209c35fd730d399dee866 # v17
         with:
           name: nix-amd-ai
           authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
@@ -66,7 +66,7 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           fetch-depth: 0
           fetch-tags: true

--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -17,9 +17,9 @@ jobs:
   check-and-update:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
-      - uses: DeterminateSystems/nix-installer-action@main
-      - uses: cachix/cachix-action@v17
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+      - uses: DeterminateSystems/nix-installer-action@ef8a148080ab6020fd15196c2084a2eea5ff2d25 # v22
+      - uses: cachix/cachix-action@38b082610b782e7e93e209c35fd730d399dee866 # v17
         with:
           name: nix-amd-ai
           authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
@@ -55,7 +55,7 @@ jobs:
       # validation build below fits. Only when vllm actually moved.
       - name: Free disk space for vllm-rocm build
         if: steps.check.outputs.vllm_needs_update == 'true'
-        uses: jlumbroso/free-disk-space@main
+        uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be # v1.3.1
 
       - name: Validate flake eval
         if: steps.check.outputs.needs_update == 'true'


### PR DESCRIPTION
Every action in `.github/` was on a mutable ref. Two on the `main` branch — `DeterminateSystems/nix-installer-action` (build.yml, update.yml) and `jlumbroso/free-disk-space` (update.yml) — and three on version tags. This pins all five to full-length commit SHAs.

### Why

Both `@main` actions run in jobs that hold `CACHIX_AUTH_TOKEN`, and in `update.yml` also `RELEASE_PAT`. A branch ref means whoever can push to those upstream repos runs code in a privileged job here. A version tag is no better — a tag can be force-moved, which is exactly the vector behind the recent action supply-chain incidents — so the three tagged actions are pinned in the same pass. A half-pinned workflow just invites the same question about the rest.

`dependabot.yml` already declares the `github-actions` ecosystem, and each SHA carries a `# vXX` comment, so dependabot keeps them current and rewrites the comment on bump. It does not track `@main` at all today, so those two were outside the one mechanism meant to watch them — pinning them actually brings them *into* the update loop rather than freezing them.

### SHAs (resolved from upstream 2026-09-05)

| action | tag | SHA |
|---|---|---|
| actions/checkout | v7 | `3d3c42e` |
| DeterminateSystems/nix-installer-action | v22 | `ef8a148` |
| cachix/cachix-action | v17 | `38b0826` |
| jlumbroso/free-disk-space | v1.3.1 | `54081f1` |
| actions/github-script | v9 | `3a2844b` |

### Two honest caveats

- **free-disk-space** `@main` currently *is* v1.3.1 (same SHA), so that pin is a functional no-op today — it only removes the future risk.
- **nix-installer-action** `@main` was ahead of the latest release by 46 commits, so this moves it from main's tip to the v22 release. And pinning this one is partial by nature: the action downloads the nix-installer binary at runtime, so the SHA pins the JS wrapper (node24 / `dist/index.js`), not what it installs. v22 has no input to pin the binary as well; later versions add `source-checksums-sha256` for that, but this pins v22. Still worth doing — it closes the wrapper as a mutable vector.

Diff is `uses:` lines only; YAML unchanged otherwise.
