### PR TITLE
fix(ci): stop losing releases to queued-run eviction and tag pushes

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,10 +6,13 @@ on:
   pull_request:
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  # Never cancel a push to main: the release job below tags only on push, so a
-  # run cancelled by the next merge drops that release for good and nothing
-  # retries it. Superseded PR runs are still worth cancelling.
+  # Each push to main gets its own group, so main runs never contend. A shared
+  # group keeps only ONE pending run: a third merge arriving while one run is
+  # in progress and another is queued evicts the queued one, and the release it
+  # would have tagged goes with it. cancel-in-progress does not cover that --
+  # it protects in-progress runs, not pending ones. PRs still share a per-ref
+  # group, where superseding a force-pushed run is the point.
+  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.event_name == 'push' && github.sha || 'pr' }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
@@ -110,6 +113,10 @@ jobs:
             title="$tag"
           fi
 
-          git tag "$tag" "$SHA"
-          git push origin "$tag"
-          printf '%s\n' "$notes" | gh release create "$tag" --title "$title" --notes-file -
+          # Create the tag through the release API rather than `git push`. A tag
+          # push from GITHUB_TOKEN is rejected -- "refusing to allow a GitHub App
+          # to create or update workflow ... without workflows permission" --
+          # whenever the tagged commit's .github/workflows differ from the branch
+          # tip, which happens as soon as a later merge lands while this job is
+          # still queued. --target takes the full SHA; an abbreviated one 422s.
+          printf '%s\n' "$notes" | gh release create "$tag" --target "$SHA" --title "$title" --notes-file -


### PR DESCRIPTION
Two more release failures today, both from merging PRs in bursts. #113 fixed one third of this problem; these are the other two.

## 1. Queued-run eviction

#113 stopped main runs being cancelled *while in progress*. But a concurrency group keeps only **one pending run**. Merging #115, #117 and #116 inside 70 seconds gave:

| Run | State when #116 arrived | Outcome |
|---|---|---|
| #115 | in progress | survived (that is #113 working) |
| #117 | **queued** | **cancelled, zero jobs started** |
| #116 | — | ran |

`cancel-in-progress` governs in-progress runs; it cannot protect a pending one. #117 happened not to touch `pkgs/`, so no release was lost — but the next one will be.

Fix: each push to `main` gets its own group, so main runs never contend. PRs keep a per-ref group, where superseding a force-pushed run is the whole point.

## 2. Tag push rejected

#115's release job failed outright:

```
! [remote rejected] v2026.09.05-3 (refusing to allow a GitHub App to create or
  update workflow `.github/workflows/build.yml` without `workflows` permission)
```

By the time that job ran, `main` had advanced past #117's `build.yml` edits, so a tag pointing at #115's older commit read as a workflow-file change coming from a token without `workflows`. This is not fixable by adding a permission — `workflows` is not grantable to `GITHUB_TOKEN`.

Fix: create the tag through the release API (`gh release create --target "$SHA"`) rather than `git tag` + `git push`. The rule only applies to ref pushes.

## Testing

Both halves are exercised, though not by CI:

- The API-tag path is how `v2026.09.05` and `v2026.09.05-3` were both cut by hand today, on this repo, with this token — including the detail now in the comment that `--target` needs the **full** SHA (an abbreviated one returns `422 Release.target_commitish is invalid`).
- `yq` parses the workflow and reads back both the group expression and the rewritten command.

The eviction half cannot be rehearsed without deliberately triple-merging again, so it rests on GitHub's documented one-pending-run-per-group behaviour plus today's observation of a cancelled run with zero jobs.

`v2026.09.05-3` has already been cut by hand, so `main` is no longer missing a release — but it is currently red from that failed job until this lands.

https://claude.ai/code/session_01GPwipeq938W3UXUBHYVuwe