### PR TITLE
docs(rocm): 7.2.3 is not broken on gfx1151, measured

### DIFF
--- a/docs/superpowers/plans/2026-07-21-therock-rocm-evaluation.md
+++ b/docs/superpowers/plans/2026-07-21-therock-rocm-evaluation.md
@@ -177,6 +177,13 @@ Do not start until the gfx1151 machine is in hand. This is the run that actually
 **METHODOLOGY CORRECTION (from community gfx1151 data — see `docs/therock-eval-results.md` "Community gfx1151 data" section):** the gfx1150 run measured ROCm's *worst* case (short ctx, plain HIP). On gfx1151, ROCm's win is at **long context with a fully-optimized build**. So Task 5 MUST:
 - Bench at **long context (8K / 16K / 32K)**, not just pp512/tg128. Report pp and tg at each length — the crossover is the whole point (Vulkan decode collapses ~32 t/s @ 8K while HIP+rocWMMA holds ~51 t/s).
 - Build the ROCm/HIP side **fully optimized: rocWMMA ON + Flash-Attention + hipBLASLt** (not plain HIP). Use TheRock ROCm (nixpkgs 7.2.3 faults on gfx1151). Vulkan side keeps `-fa` too.
+
+> **Correction (2026-09-05):** the "nixpkgs ROCm 7.2.3 faults on gfx1151"
+> premise in this dated document is false — measured on a Ryzen AI MAX+ 395,
+> stock `llama-cpp-rocm` runs there without faulting. See the Correction
+> section in `docs/therock-eval-results.md`. Left otherwise unedited as a
+> record of what was believed at the time.
+
 - Frame the go/no-go around the **coding-agent (long-context) regime**, which is the actual reason for Strix Halo — not short-context chat.
 
 **Files:**

--- a/docs/superpowers/specs/2026-07-21-therock-rocm-design.md
+++ b/docs/superpowers/specs/2026-07-21-therock-rocm-design.md
@@ -8,7 +8,14 @@
 
 The flake's own README benchmarks (gfx1150) recommend **Vulkan** for general LLM inference: Vulkan wins decode at every size tested (+26% on Gemma-26B tg128) and ties/wins prefill; ROCm is "kept as a fallback and for ecosystem tooling." whisper already runs Vulkan; RADV/Vulkan is arch-agnostic and works on gfx1151.
 
-**But that data is Vulkan vs *nixpkgs ROCm 7.2.3*** — the old runtime with known gfx1151 VRAM faults. The open question is whether **up-to-date TheRock ROCm (native gfx1151 kernels)** changes that verdict. Nobody has that A/B. Vendoring a whole per-arch SDK + rebuilding backends is a large, ongoing, solo-maintained cost (see "Integration cost" below); we do not pay it on an unmeasured premise.
+**But that data is Vulkan vs *nixpkgs ROCm 7.2.3*** — the old runtime with known gfx1151 VRAM faults.
+
+> **Correction (2026-09-05):** the "nixpkgs ROCm 7.2.3 faults on gfx1151"
+> premise in this dated document is false — measured on a Ryzen AI MAX+ 395,
+> stock `llama-cpp-rocm` runs there without faulting. See the Correction
+> section in `docs/therock-eval-results.md`. Left otherwise unedited as a
+> record of what was believed at the time.
+ The open question is whether **up-to-date TheRock ROCm (native gfx1151 kernels)** changes that verdict. Nobody has that A/B. Vendoring a whole per-arch SDK + rebuilding backends is a large, ongoing, solo-maintained cost (see "Integration cost" below); we do not pay it on an unmeasured premise.
 
 So: **measure first (Phase 0). Integrate only if TheRock ROCm meaningfully beats Vulkan on the backend that matters.**
 

--- a/docs/therock-eval-results.md
+++ b/docs/therock-eval-results.md
@@ -267,9 +267,10 @@ premise "latest ROCm ⇒ better llama.cpp" is **falsified on this hardware**.
 backends already work. The real target is **gfx1151 (Strix Halo)**, and two
 questions remain genuinely open there, both hardware-gated:
 
-1. **gfx1151 llama.cpp:** old nixpkgs ROCm 7.2.3 is *broken* on gfx1151 (VRAM
-   faults), and TheRock ships *native gfx1151 kernels*. The gfx1150 numbers
-   strongly suggest Vulkan still wins — but only the gfx1151 A/B settles it.
+1. **gfx1151 llama.cpp:** TheRock ships *native gfx1151 kernels*. The gfx1150
+   numbers strongly suggest Vulkan still wins — but only the gfx1151 A/B
+   settles it. (This item previously said nixpkgs ROCm 7.2.3 was broken on
+   gfx1151 with VRAM faults. It is not — see "Correction" below.)
 2. **Image gen (sd-cpp):** not yet tested; the likeliest place ROCm still
    beats Vulkan. Needs a Vulkan-sd-cpp-vs-TheRock-ROCm-sd A/B.
 
@@ -302,8 +303,10 @@ that flip the picture for the coding-agent (long-context) goal:
    hipBLASLt**. The flake's `llama-cpp-rocm` is plain (rocWMMA off — it
    *regressed* on gfx1150). Realizing the gfx1151 win needs a **per-arch
    build: rocWMMA ON for gfx1151, OFF for gfx1150.**
-3. On gfx1151 nixpkgs ROCm 7.2.3 *faults*, so the long-context win likely
-   needs **newer ROCm (TheRock) + rocWMMA + FA + hipBLASLt** together — a
+3. The winning config may need **rocWMMA + FA + hipBLASLt** together. It does
+   *not* obviously need TheRock: `rocmPackages.rocwmma` is in nixpkgs at the
+   same 7.2.3, so the optimized build is reachable as an override on the
+   existing package. Test that before reopening the vendoring question — a
    narrow, specific case for up-to-date ROCm, not the vague "newer is better"
    premise (which this gfx1150 run correctly falsified).
 
@@ -312,3 +315,36 @@ that flip the picture for the coding-agent (long-context) goal:
 not pp512/tg128 plain-HIP — otherwise it measures ROCm's worst case and
 misses its only win. Image-gen (sd-cpp) is unaffected (not long-token-decode)
 — Vulkan sd-cpp remains the right cheap path there.
+
+## Correction (2026-09-05): nixpkgs ROCm 7.2.3 is not broken on gfx1151
+
+The "7.2.3 faults on gfx1151 (VRAM faults)" claim above was written before this
+project had Strix Halo hardware. It is now measured, and it is wrong.
+
+Host: Ryzen AI MAX+ 395 (gfx1151), 128 GB, `ttmSizeGiB = 104`, kernel 7.2.2,
+linux-firmware 20260810. Stock `llama-cpp-rocm` from the flake's pinned nixpkgs
+(llama.cpp build 10566, ROCm 7.2.3), no override:
+
+```
+$ llama-bench -m Qwen3.5-4B-UD-Q4_K_XL.gguf -p 512 -n 32 -r 2 -fa 1
+ggml_cuda_init: found 1 ROCm devices (Total VRAM: 106496 MiB):
+  Device 0: AMD Radeon 8060S Graphics, gfx1151 (0x1151), VMM: no, Wave Size: 32
+
+| qwen35 4B Q4_K | ROCm | fa 1 | pp512 | 1893.44 ± 52.29 |
+| qwen35 4B Q4_K | ROCm | fa 1 |  tg32 |    57.87 ± 0.14 |
+```
+
+It enumerates the device with the right arch, addresses the full GTT pool, and
+completes both passes. No fault.
+
+**Treat these as a crash/no-crash result, not as performance data.** This host
+runs the kernel + firmware pair reported in #105 as making models misbehave, so
+throughput measured on it today is not trustworthy. "It does not fault" survives
+that doubt; "it runs at 1893 t/s" does not, and must not be quoted as a baseline.
+
+What this changes: the argument for vendoring TheRock rested partly on gfx1151
+being unusable without it. That leg is gone. Combined with the gfx1150 A/B above
+(newer ROCm lost) and the fact that nixpkgs-unstable is *also* at 7.2.3 — so
+there is no cheap bump, only vendoring — the remaining case for TheRock is the
+narrow rocWMMA + FA + hipBLASLt long-context one, and even that should first be
+tried as an override on nixpkgs, which already carries `rocmPackages.rocwmma`.


### PR DESCRIPTION
The claim that nixpkgs ROCm 7.2.3 faults on gfx1151 was written before this project had Strix Halo hardware. It is now measured, and it is false.

Host: Ryzen AI MAX+ 395 (gfx1151), 128 GB, `ttmSizeGiB = 104`. Stock `llama-cpp-rocm` from the flake's pinned nixpkgs — llama.cpp build 10566, ROCm 7.2.3, no override:

```
ggml_cuda_init: found 1 ROCm devices (Total VRAM: 106496 MiB):
  Device 0: AMD Radeon 8060S Graphics, gfx1151 (0x1151), VMM: no, Wave Size: 32

| qwen35 4B Q4_K | ROCm | fa 1 | pp512 | 1893.44 ± 52.29 |
| qwen35 4B Q4_K | ROCm | fa 1 |  tg32 |    57.87 ± 0.14 |
```

Right arch, full GTT pool addressed, both passes complete. No fault.

**Deliberately recorded as crash/no-crash, not as performance data.** This host runs the kernel 7.2.2 + linux-firmware 20260810 pair reported in #105, so throughput from it is untrustworthy. "It does not fault" survives that doubt; "1893 t/s" does not, and the doc says so explicitly rather than leaving a number that will get quoted as a baseline later.

## Why it matters

The case for vendoring TheRock had three legs. Two were already down and this removes the third:

| Leg | Status |
|---|---|
| "newer ROCm is faster" | already falsified by the gfx1150 A/B **in this same document** — TheRock 7.13.0 lost by ~3–5% prefill, ~10–11% decode |
| "we can just bump nixpkgs" | no such path — `nixpkgs-unstable` is *also* at `rocm-core` 7.2.3 |
| "we have to, 7.2.3 faults on gfx1151" | **false, measured here** |

What remains is the narrow rocWMMA + FA + hipBLASLt long-context case. That one is still open — but `rocmPackages.rocwmma` is already in nixpkgs at 7.2.3, so it is reachable as an override on the existing package and does not require a 16 GB SDK fetch at ~350 KB/s plus the four undocumented NixOS build fixes this document records.

## Scope

- `docs/therock-eval-results.md` — the living results doc. Both occurrences corrected, plus a dated Correction section carrying the measurement.
- `docs/superpowers/{plans,specs}/2026-07-21-therock-*` — **annotated, not rewritten.** They are dated records of what was believed in July; a blockquote points at the correction so the premise is not read as current.

One thing I got wrong when proposing this: I said the bring-up checklist also carried the claim. It does not — the propagation is the two July planning documents. The checklist is separately stale for other reasons (its kernel window says ~6.18.x against an actual 7.2.2, and it says "nothing here has been run" when Phases 0–2 now have), which is worth its own PR rather than being folded in here.

https://claude.ai/code/session_01GPwipeq938W3UXUBHYVuwe